### PR TITLE
fix: 修复加密文章提交按钮文字被遮挡的问题

### DIFF
--- a/themes/claude/components/ArticleLock.js
+++ b/themes/claude/components/ArticleLock.js
@@ -39,10 +39,11 @@ export default function ArticleLock (props) {
                       }
                     }}
                     ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-                    className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
+                    className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
                 ></input>
-                <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300" >
-                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+                <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none" >
+                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} />
+                    <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
                 </div>
             </div>
             <div id='tips'>

--- a/themes/commerce/components/ArticleLock.js
+++ b/themes/commerce/components/ArticleLock.js
@@ -38,10 +38,11 @@ export const ArticleLock = props => {
               }
             }}
             ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-            className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg  font-light leading-10 bg-gray-100 dark:bg-gray-500'>
+            className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg  font-light leading-10 bg-gray-100 dark:bg-gray-500'>
         </input>
-        <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 bg-red-500 hover:bg-red-400 text-white rounded-r duration-300" >
-          <i className={'duration-200 cursor-pointer fas fa-key'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+        <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 bg-red-500 hover:bg-red-400 text-white rounded-r duration-300 select-none" >
+          <i className={'duration-200 cursor-pointer fas fa-key'} />
+          <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
         </div>
       </div>
       <div id='tips'>

--- a/themes/example/components/PostLock.js
+++ b/themes/example/components/PostLock.js
@@ -44,16 +44,16 @@ export const PostLock = props => {
               }
             }}
             ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-            className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'></input>
+            className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'></input>
           <div
             onClick={submitPassword}
-            className='px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300'>
+            className='flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none'>
             <i
               className={
                 'duration-200 cursor-pointer fas fa-key dark:text-black'
-              }>
-              &nbsp;{locale.COMMON.SUBMIT}
-            </i>
+              }
+            />
+            <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
           </div>
         </div>
         <div id='tips'></div>

--- a/themes/fukasawa/components/ArticleLock.js
+++ b/themes/fukasawa/components/ArticleLock.js
@@ -43,13 +43,14 @@ const ArticleLock = props => {
                 }
               }}
               ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-              className="outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg  font-light leading-10 bg-gray-100 dark:bg-gray-500"
+              className="outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg  font-light leading-10 bg-gray-100 dark:bg-gray-500"
             ></input>
             <div
               onClick={submitPassword}
-              className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 bg-gray-700 hover:bg-gray-400 text-white rounded-r duration-300"
+              className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 bg-gray-700 hover:bg-gray-400 text-white rounded-r duration-300 select-none"
             >
-              <i className={'duration-200 cursor-pointer fas fa-key'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+              <i className={'duration-200 cursor-pointer fas fa-key'} />
+              <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
             </div>
           </div>
           <div id="tips"></div>

--- a/themes/game/components/ArticleLock.js
+++ b/themes/game/components/ArticleLock.js
@@ -40,10 +40,11 @@ export const ArticleLock = props => {
                       }
                     }}
                     ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-                    className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
+                    className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
                 ></input>
-                <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300" >
-                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+                <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none" >
+                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} />
+                    <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
                 </div>
             </div>
             <div id='tips'>

--- a/themes/gitbook/components/ArticleLock.js
+++ b/themes/gitbook/components/ArticleLock.js
@@ -51,13 +51,12 @@ export const ArticleLock = props => {
               }
             }}
             ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-            className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg dark:text-gray-300 font-light leading-10 text-black bg-gray-100 dark:bg-gray-500'></input>
+            className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg dark:text-gray-300 font-light leading-10 text-black bg-gray-100 dark:bg-gray-500'></input>
           <div
             onClick={submitPassword}
-            className='px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 bg-green-500 hover:bg-green-400 text-white rounded-r duration-300'>
-            <i className={'duration-200 cursor-pointer fas fa-key'}>
-              &nbsp;{locale.COMMON.SUBMIT}
-            </i>
+            className='flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 bg-green-500 hover:bg-green-400 text-white rounded-r duration-300 select-none'>
+            <i className={'duration-200 cursor-pointer fas fa-key'} />
+            <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
           </div>
         </div>
         <div id='tips'></div>

--- a/themes/heo/components/PostLock.js
+++ b/themes/heo/components/PostLock.js
@@ -49,13 +49,12 @@ export const PostLock = props => {
               }
             }}
             ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-            className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg  font-light leading-10 bg-gray-100 dark:bg-gray-500'></input>
+            className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg  font-light leading-10 bg-gray-100 dark:bg-gray-500'></input>
           <div
             onClick={submitPassword}
-            className='px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 bg-[var(--heo-color-primary)] hover:bg-[var(--heo-color-primary-hover)] text-[var(--heo-color-primary-text)] rounded-r duration-300'>
-            <i className={'duration-200 cursor-pointer fas fa-key'}>
-              &nbsp;{locale.COMMON.SUBMIT}
-            </i>
+            className='flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 bg-[var(--heo-color-primary)] hover:bg-[var(--heo-color-primary-hover)] text-[var(--heo-color-primary-text)] rounded-r duration-300 select-none'>
+            <i className={'duration-200 cursor-pointer fas fa-key'} />
+            <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
           </div>
         </div>
         <div id='tips'>

--- a/themes/hexo/components/ArticleLock.js
+++ b/themes/hexo/components/ArticleLock.js
@@ -38,10 +38,11 @@ export const ArticleLock = props => {
               }
             }}
             ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-            className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg  font-light leading-10 bg-gray-100 dark:bg-gray-500'>
+            className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg  font-light leading-10 bg-gray-100 dark:bg-gray-500'>
         </input>
-        <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 bg-indigo-500 hover:bg-indigo-400 text-white rounded-r duration-300" >
-          <i className={'duration-200 cursor-pointer fas fa-key'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+        <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 bg-indigo-500 hover:bg-indigo-400 text-white rounded-r duration-300 select-none" >
+          <i className={'duration-200 cursor-pointer fas fa-key'} />
+          <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
         </div>
       </div>
       <div id='tips'>

--- a/themes/magzine/components/ArticleLock.js
+++ b/themes/magzine/components/ArticleLock.js
@@ -45,13 +45,12 @@ export const ArticleLock = props => {
               }
             }}
             ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-            className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg dark:text-gray-300  leading-10 text-black bg-gray-100 dark:bg-gray-500'></input>
+            className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg dark:text-gray-300  leading-10 text-black bg-gray-100 dark:bg-gray-500'></input>
           <div
             onClick={submitPassword}
-            className='px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 bg-gray-500 hover:bg-gray-400 text-white rounded-r duration-300'>
-            <i className={'duration-200 cursor-pointer fas fa-key'}>
-              &nbsp;{locale.COMMON.SUBMIT}
-            </i>
+            className='flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 bg-gray-500 hover:bg-gray-400 text-white rounded-r duration-300 select-none'>
+            <i className={'duration-200 cursor-pointer fas fa-key'} />
+            <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
           </div>
         </div>
         <div id='tips'></div>

--- a/themes/medium/components/ArticleLock.js
+++ b/themes/medium/components/ArticleLock.js
@@ -40,10 +40,11 @@ export const ArticleLock = props => {
               }
             }}
             ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-            className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg dark:text-gray-300 font-light leading-10 text-black bg-gray-100 dark:bg-gray-500'>
+            className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg dark:text-gray-300 font-light leading-10 text-black bg-gray-100 dark:bg-gray-500'>
         </input>
-        <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 bg-green-500 hover:bg-green-400 text-white rounded-r duration-300" >
-          <i className={'duration-200 cursor-pointer fas fa-key'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+        <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 bg-green-500 hover:bg-green-400 text-white rounded-r duration-300 select-none" >
+          <i className={'duration-200 cursor-pointer fas fa-key'} />
+          <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
         </div>
       </div>
       <div id='tips'>

--- a/themes/movie/components/ArticleLock.js
+++ b/themes/movie/components/ArticleLock.js
@@ -39,10 +39,11 @@ export const ArticleLock = props => {
                       }
                     }}
                     ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-                    className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
+                    className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
                 ></input>
-                <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300" >
-                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+                <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none" >
+                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} />
+                    <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
                 </div>
             </div>
             <div id='tips'>

--- a/themes/nav/components/ArticleLock.js
+++ b/themes/nav/components/ArticleLock.js
@@ -40,10 +40,11 @@ export const ArticleLock = props => {
               }
             }}
             ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-            className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg dark:text-gray-300 font-light leading-10 text-black bg-gray-100 dark:bg-gray-500'>
+            className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg dark:text-gray-300 font-light leading-10 text-black bg-gray-100 dark:bg-gray-500'>
         </input>
-        <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 bg-green-500 hover:bg-green-400 text-white rounded-r duration-300" >
-          <i className={'duration-200 cursor-pointer fas fa-key'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+        <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 bg-green-500 hover:bg-green-400 text-white rounded-r duration-300 select-none" >
+          <i className={'duration-200 cursor-pointer fas fa-key'} />
+          <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
         </div>
       </div>
       <div id='tips'>

--- a/themes/next/components/ArticleLock.js
+++ b/themes/next/components/ArticleLock.js
@@ -43,13 +43,14 @@ export const ArticleLock = props => {
                 }
               }}
               ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-              className="outline-none w-full text-sm pl-5 transition focus:shadow-lg font-light leading-10 bg-gray-100 dark:bg-gray-500"
+              className="outline-none flex-1 min-w-0 text-sm pl-5 transition focus:shadow-lg font-light leading-10 bg-gray-100 dark:bg-gray-500"
             ></input>
             <div
               onClick={submitPassword}
-              className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 bg-gray-700 hover:bg-gray-400 text-white duration-300"
+              className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 bg-gray-700 hover:bg-gray-400 text-white rounded-r duration-300 select-none"
             >
-              <i className={'duration-200 cursor-pointer fas fa-key'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+              <i className={'duration-200 cursor-pointer fas fa-key'} />
+              <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
             </div>
           </div>
           <div id="tips"></div>

--- a/themes/nobelium/components/ArticleLock.js
+++ b/themes/nobelium/components/ArticleLock.js
@@ -40,10 +40,11 @@ export const ArticleLock = props => {
                       }
                     }}
                     ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-                    className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
+                    className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
                 ></input>
-                <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300" >
-                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+                <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none" >
+                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} />
+                    <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
                 </div>
             </div>
             <div id='tips'>

--- a/themes/photo/components/ArticleLock.js
+++ b/themes/photo/components/ArticleLock.js
@@ -39,10 +39,11 @@ export const ArticleLock = props => {
                       }
                     }}
                     ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-                    className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
+                    className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
                 ></input>
-                <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300" >
-                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+                <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none" >
+                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} />
+                    <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
                 </div>
             </div>
             <div id='tips'>

--- a/themes/plog/components/ArticleLock.js
+++ b/themes/plog/components/ArticleLock.js
@@ -40,10 +40,11 @@ export const ArticleLock = props => {
                       }
                     }}
                     ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-                    className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
+                    className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
                 ></input>
-                <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300" >
-                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+                <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none" >
+                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} />
+                    <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
                 </div>
             </div>
             <div id='tips'>

--- a/themes/proxio/components/ArticleLock.js
+++ b/themes/proxio/components/ArticleLock.js
@@ -40,10 +40,11 @@ export const ArticleLock = props => {
                       }
                     }}
                     ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-                    className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
+                    className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
                 ></input>
-                <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300" >
-                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+                <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none" >
+                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} />
+                    <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
                 </div>
             </div>
             <div id='tips'>

--- a/themes/simple/components/ArticleLock.js
+++ b/themes/simple/components/ArticleLock.js
@@ -39,10 +39,11 @@ export default function ArticleLock (props) {
                       }
                     }}
                     ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-                    className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
+                    className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
                 ></input>
-                <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300" >
-                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+                <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none" >
+                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} />
+                    <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
                 </div>
             </div>
             <div id='tips'>

--- a/themes/starter/components/ArticleLock.js
+++ b/themes/starter/components/ArticleLock.js
@@ -40,10 +40,11 @@ export const ArticleLock = props => {
                       }
                     }}
                     ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-                    className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
+                    className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
                 ></input>
-                <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300" >
-                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+                <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none" >
+                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} />
+                    <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
                 </div>
             </div>
             <div id='tips'>

--- a/themes/typography/components/ArticleLock.js
+++ b/themes/typography/components/ArticleLock.js
@@ -39,10 +39,11 @@ export default function ArticleLock (props) {
                       }
                     }}
                     ref={passwordInputRef} // 绑定ref到passwordInputRef变量
-                    className='outline-none w-full text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
+                    className='outline-none flex-1 min-w-0 text-sm pl-5 rounded-l transition focus:shadow-lg font-light leading-10 text-black dark:bg-gray-500 bg-gray-50'
                 ></input>
-                <div onClick={submitPassword} className="px-3 whitespace-nowrap cursor-pointer items-center justify-center py-2 rounded-r duration-300 bg-gray-300" >
-                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} >&nbsp;{locale.COMMON.SUBMIT}</i>
+                <div onClick={submitPassword} className="flex items-center justify-center whitespace-nowrap cursor-pointer px-4 leading-10 rounded-r duration-300 bg-gray-300 select-none" >
+                    <i className={'duration-200 cursor-pointer fas fa-key dark:text-black'} />
+                    <span className='ml-1'>{locale.COMMON.SUBMIT}</span>
                 </div>
             </div>
             <div id='tips'>


### PR DESCRIPTION
## 问题描述

加密文章的密码输入框旁边的「提交」按钮文字被遮挡，只显示「提」而「交」被隐藏。

## 根本原因

CSS flex 布局问题：
1. `input` 使用 `w-full` 在 flex 容器中占据全部宽度，挤压按钮至接近 0 宽度
2. 按钮 `div` 缺少 `flex` 类，无法正确排列内容
3. `<i>` 标签内的文本在按钮被挤压时被裁剪

## 修复方案

参照已正确实现的 `matery`/`fuwari`/`thoughtlite` 主题：
- `input`: `w-full` → `flex-1 min-w-0`（允许 input 收缩，不再挤压按钮）
- button `div`: 添加 `flex` 类，`px-3` → `px-4`，`py-2` → `leading-10`
- `<i>&nbsp;提交</i>` → `<i />` + `<span className="ml-1">{locale.COMMON.SUBMIT}</span>`（图标和文字分离，避免裁剪）

## 修复范围

共修复 **20 个主题**的 Lock 组件：

| 批次 | 主题 | 文件 |
|------|------|------|
| 第1批 | hexo | `themes/hexo/components/ArticleLock.js` |
| 第1批 | next | `themes/next/components/ArticleLock.js` |
| 第1批 | nobelium | `themes/nobelium/components/ArticleLock.js` |
| 第1批 | gitbook | `themes/gitbook/components/ArticleLock.js` |
| 第1批 | photo | `themes/photo/components/ArticleLock.js` |
| 第1批 | movie | `themes/movie/components/ArticleLock.js` |
| 第1批 | plog | `themes/plog/components/ArticleLock.js` |
| 第1批 | nav | `themes/nav/components/ArticleLock.js` |
| 第1批 | claude | `themes/claude/components/ArticleLock.js` |
| 第1批 | example | `themes/example/components/PostLock.js` |
| 第2批 | heo | `themes/heo/components/PostLock.js` |
| 第2批 | simple | `themes/simple/components/ArticleLock.js` |
| 第2批 | commerce | `themes/commerce/components/ArticleLock.js` |
| 第2批 | fukasawa | `themes/fukasawa/components/ArticleLock.js` |
| 第2批 | game | `themes/game/components/ArticleLock.js` |
| 第2批 | magzine | `themes/magzine/components/ArticleLock.js` |
| 第2批 | medium | `themes/medium/components/ArticleLock.js` |
| 第2批 | proxio | `themes/proxio/components/ArticleLock.js` |
| 第2批 | starter | `themes/starter/components/ArticleLock.js` |
| 第2批 | typography | `themes/typography/components/ArticleLock.js` |

**未修改的主题**（已正确实现或布局不同）：
- `matery`, `fuwari`, `thoughtlite` — 已使用正确的 flex 布局
- `endspace` — 按钮在输入框下方，非并排布局，无此问题

## 测试方式

在任意主题下打开一篇加密文章，确认提交按钮完整显示「🔑 提交」，且输入框和按钮在不同屏幕宽度下均正常显示。

## 截图

| Before | After |
|--------|-------|
| 按钮只显示「提」 | 按钮完整显示「🔑 提交」 |