### PR TITLE
fix(callout): 修复 Callout 嵌套子块内容不渲染

### DIFF
--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -7,11 +7,7 @@ import mediumZoom from '@fisch0920/medium-zoom'
 import 'katex/dist/katex.min.css'
 import dynamic from 'next/dynamic'
 import { useEffect, useRef } from 'react'
-import {
-  NotionRenderer,
-  PageIcon,
-  Text as NotionRendererText
-} from 'react-notion-x'
+import { NotionRenderer } from 'react-notion-x'
 import OriginalityProof from './OriginalityProof'
 
 /**
@@ -132,7 +128,6 @@ const NotionPage = ({ post, className }) => {
           Modal,
           Pdf,
           Quote: NotionQuote,
-          Callout: NotionCallout,
           Tweet
         }}
       />
@@ -313,29 +308,6 @@ const NotionQuote = ({ block, children }) => {
       {title && <NotionText value={title} />}
       {children}
     </blockquote>
-  )
-}
-
-const NotionCallout = ({ block, className, children }) => {
-  const blockColor = block?.format?.block_color
-  const hasIcon = Boolean(block?.format?.page_icon)
-  const classNames = [
-    'notion-callout',
-    blockColor ? `notion-${blockColor}_co` : '',
-    hasIcon ? '' : 'notion-callout-no-icon',
-    className || ''
-  ].filter(Boolean).join(' ')
-
-  return (
-    <div className={classNames}>
-      {hasIcon && <PageIcon block={block} hideDefaultIcon />}
-      <div
-        className='notion-callout-text'
-        style={hasIcon ? undefined : { marginLeft: 0 }}>
-        <NotionRendererText value={block?.properties?.title} block={block} />
-        {children}
-      </div>
-    </div>
   )
 }
 

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -1014,6 +1014,10 @@ code[class*='language-'] {
   overflow: hidden;
 }
 
+.notion-callout > .notion-callout-text:first-child {
+  margin-left: 0;
+}
+
 .notion-callout-text .notion-text{
   padding: 0px 0px !important;
   margin: 0px 0px !important;


### PR DESCRIPTION
## 已知问题

1. PR #4394 引入的自定义 `NotionCallout` 组件导致 Callout 嵌套子块内容丢失
   - react-notion-x v7.10.0 调用自定义 Callout 组件时只传 `{ block, className }`，**不传 `children`**
   - 自定义 `NotionCallout` 依赖 `children` 渲染子块，`children` 恒为 `undefined`
   - 表现：Callout 内的段落、列表、链接等子块全部不渲染，只显示 `properties.title`（第一行）

## 解决方案

1. 移除自定义 `NotionCallout` 组件及 `components.Callout` 注册，回退到 react-notion-x 默认 Callout 渲染器
   - 默认渲染器已正确处理 `children`（子块递归渲染）
   - 默认渲染器已支持 `hideDefaultIcon: true`（无图标时不显示占位符）
   - 默认渲染器已正确渲染 `Text`（富文本）和 `block_color`（颜色）
2. 添加 CSS `.notion-callout > .notion-callout-text:first-child { margin-left: 0; }` 修复无图标时的左间距
   - 无图标时 `PageIcon` 返回 `null`，React 不渲染节点，`.notion-callout-text` 成为 `:first-child`
   - 此时默认的 `margin-left: 8px` 是多余的，CSS 将其归零
3. `normalizeCalloutBlock`（`getPostBlocks.js`）保留不变，仍用于归一化新 API 格式的 callout 数据

## 改动收益

1. Callout 块内所有子内容（段落、列表、链接等）恢复正常渲染
2. 无图标 Callout 不再有多余左间距
3. 不引入新组件，减少自定义渲染逻辑的维护负担

## 具体改动

1. `components/NotionPage.js`
   - 移除 `PageIcon`、`Text as NotionRendererText` 的 import（-2 行）
   - 移除 `Callout: NotionCallout` 组件注册（-1 行）
   - 移除 `NotionCallout` 组件定义（-26 行）
2. `styles/notion.css`
   - 新增 `.notion-callout > .notion-callout-text:first-child { margin-left: 0; }`（+4 行）

## 测试确认

- [x] 本地开发环境测试通过（Callout 子块内容正常渲染）
- [x] 生产环境构建测试通过
- [x] 无图标 Callout 左间距正常
- [x] 有图标 Callout 渲染正常
- [x] `normalizeCalloutBlock` 单元测试不受影响（未修改 `getPostBlocks.js`）

## 用户文档（`docs/user-guide/` / `docs/developer/`）

- [x] 不适用（无文档改动）

---

Fixes #4400

Regression from #4394