### PR TITLE
fix: PrismMac 代码侧栏 modal 行为修复（滚动锁定+响应式+aria-modal+焦点陷阱）

### DIFF
--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -185,7 +185,7 @@ const loadPrismMacStyleCSS = () => {
 
 const CODE_SIDE_PANEL_ID = 'notion-code-side-panel'
 const CODE_SIDE_PANEL_DESKTOP_QUERY = '(min-width: 1024px)'
-const CODE_SIDE_PANEL_KEYDOWN = '__notionNextCodeSidePanelKeydown'
+const CODE_SIDE_PANEL_STATE = '__notionNextCodeSidePanelState'
 
 export const isCodeSidePanelSupported = () => {
   if (typeof window === 'undefined') return false
@@ -201,10 +201,27 @@ export const closeCodeSidePanel = () => {
   if (existing) existing.remove()
 
   if (typeof window !== 'undefined') {
-    const keydownHandler = window[CODE_SIDE_PANEL_KEYDOWN]
-    if (keydownHandler) {
-      document.removeEventListener('keydown', keydownHandler)
-      delete window[CODE_SIDE_PANEL_KEYDOWN]
+    const state = window[CODE_SIDE_PANEL_STATE]
+    if (state?.keydownHandler) {
+      document.removeEventListener('keydown', state.keydownHandler)
+    }
+    if (state?.desktopQuery && state.viewportHandler) {
+      if (typeof state.desktopQuery.removeEventListener === 'function') {
+        state.desktopQuery.removeEventListener('change', state.viewportHandler)
+      } else {
+        state.desktopQuery.removeListener?.(state.viewportHandler)
+      }
+    }
+    if (state && document.body) {
+      document.body.style.overflow = state.bodyOverflow
+    }
+    if (state && document.documentElement) {
+      document.documentElement.style.overflow = state.documentOverflow
+    }
+    delete window[CODE_SIDE_PANEL_STATE]
+
+    if (state?.returnFocus?.isConnected) {
+      state.returnFocus.focus()
     }
   }
 
@@ -229,6 +246,10 @@ export const openCodeSidePanel = ({
     return false
   }
 
+  const returnFocus =
+    document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null
   closeCodeSidePanel()
 
   const root = document.createElement('div')
@@ -245,7 +266,7 @@ export const openCodeSidePanel = ({
   drawer.className = 'code-side-panel-drawer'
   drawer.setAttribute('role', 'dialog')
   drawer.setAttribute('aria-label', '代码预览侧栏')
-  drawer.setAttribute('aria-modal', 'false')
+  drawer.setAttribute('aria-modal', 'true')
 
   const header = document.createElement('div')
   header.className = 'code-side-panel-header'
@@ -317,13 +338,59 @@ export const openCodeSidePanel = ({
   root.appendChild(drawer)
 
   const keydownHandler = event => {
-    if (event.key === 'Escape') closeCodeSidePanel()
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeCodeSidePanel()
+      return
+    }
+    if (event.key !== 'Tab') return
+
+    const activeElement = document.activeElement
+    if (
+      event.shiftKey &&
+      (activeElement === copyButton || !drawer.contains(activeElement))
+    ) {
+      event.preventDefault()
+      closeButton.focus()
+    } else if (
+      !event.shiftKey &&
+      (activeElement === closeButton || !drawer.contains(activeElement))
+    ) {
+      event.preventDefault()
+      copyButton.focus()
+    }
   }
-  window[CODE_SIDE_PANEL_KEYDOWN] = keydownHandler
+  const desktopQuery =
+    typeof window.matchMedia === 'function'
+      ? window.matchMedia(CODE_SIDE_PANEL_DESKTOP_QUERY)
+      : null
+  const viewportHandler = event => {
+    if (!event.matches) closeCodeSidePanel()
+  }
+  if (typeof desktopQuery?.addEventListener === 'function') {
+    desktopQuery.addEventListener('change', viewportHandler)
+  } else {
+    desktopQuery?.addListener?.(viewportHandler)
+  }
+  window[CODE_SIDE_PANEL_STATE] = {
+    bodyOverflow: document.body?.style.overflow || '',
+    documentOverflow: document.documentElement?.style.overflow || '',
+    desktopQuery,
+    viewportHandler,
+    keydownHandler,
+    returnFocus
+  }
   document.addEventListener('keydown', keydownHandler)
+  if (document.body) document.body.style.overflow = 'hidden'
+  if (document.documentElement) {
+    document.documentElement.style.overflow = 'hidden'
+  }
 
   document.body.appendChild(root)
-  requestFrame(() => root.classList.add('is-open'))
+  closeButton.focus()
+  requestFrame(() => {
+    if (root.isConnected) root.classList.add('is-open')
+  })
 
   return true
 }


### PR DESCRIPTION
## 背景

上游 PR #4350（`feat: add code sidebar preview`）在 `components/PrismMac.js` 中引入了代码侧栏，但缺少背景滚动锁定、响应式监听、正确的 `aria-modal` 和焦点陷阱。详见 Issue #4404。

---

## 修复内容

Fixes #4404

### Bug 1: 背景滚动锁定

打开侧栏时保存并锁定 `body` 和 `html` 的 `overflow: hidden`，关闭时恢复原值。

### Bug 2: 响应式自动关闭

使用 `matchMedia` 监听断点变化，从桌面缩小到移动端时自动调用 `closeCodeSidePanel`。

### Bug 3: `aria-modal` 修正

将 `aria-modal` 从 `'false'` 改为 `'true'`。

### Bug 4: 焦点陷阱

侧栏打开时，Tab/Shift+Tab 在 copy 和 close 按钮之间循环，防止焦点逃逸。关闭时焦点恢复到打开前的元素。

## 改动文件

- `components/PrismMac.js`：+76/-9

## 测试

- ✅ 侧栏打开时背景不可滚动
- ✅ 桌面缩小到移动端侧栏自动关闭
- ✅ Tab 键焦点困在侧栏内
- ✅ 关闭后焦点恢复
- ✅ 括号平衡检查通过