### PR TITLE
feat(theme): animate settings console drawer

### DIFF
--- a/components/ThemeSwitch.js
+++ b/components/ThemeSwitch.js
@@ -86,7 +86,7 @@ function PaletteField ({ item, value, copyValue, isHexColor, updateItem, resetIt
   )
 }
 
-function ThemeConsole ({ meta, onClose }) {
+function ThemeConsole ({ meta, isOpen, onClose }) {
   const { updateRuntimeConfigOverride, THEME_CONFIG } = useGlobal()
   const noticeTimerRef = useRef(null)
   const [values, setValues] = useState({})
@@ -314,7 +314,14 @@ function ThemeConsole ({ meta, onClose }) {
     <Draggable stick={true}>
       <section
         style={{ right: '1rem', top: '10vh' }}
-        className='fixed z-50 w-[min(94vw,40rem)] overflow-hidden rounded-2xl border border-gray-200/80 bg-white/95 shadow-2xl ring-1 ring-black/5 backdrop-blur-xl dark:border-gray-700/70 dark:bg-gray-950/95 dark:ring-white/10 sm:w-[min(92vw,42rem)]'>
+        role='dialog'
+        aria-label={`主题控制台 · ${meta.name}`}
+        aria-hidden={!isOpen}
+        className={`fixed z-50 w-[min(94vw,40rem)] overflow-hidden rounded-2xl border border-gray-200/80 bg-white/95 shadow-2xl ring-1 ring-black/5 backdrop-blur-xl transition-[transform,opacity] duration-200 ease-out will-change-transform motion-reduce:transform-none motion-reduce:transition-none dark:border-gray-700/70 dark:bg-gray-950/95 dark:ring-white/10 sm:w-[min(92vw,42rem)] ${
+          isOpen
+            ? 'translate-x-0 opacity-100'
+            : 'translate-x-[calc(100%+2rem)] opacity-0'
+        }`}>
         <div className='flex items-start justify-between gap-3 border-b border-gray-100 px-4 py-3 dark:border-gray-800'>
           <div className='min-w-0'>
             <p className='text-sm font-semibold text-gray-900 dark:text-white'>
@@ -565,7 +572,24 @@ const ThemeSwitch = () => {
   const router = useRouter()
   const currentTheme = getQueryParam(router.asPath, 'theme') || theme
   const [sideBarVisible, setSideBarVisible] = useState(false)
+  const [consoleMounted, setConsoleMounted] = useState(false)
   const [consoleVisible, setConsoleVisible] = useState(false)
+
+  useEffect(() => {
+    if (!consoleMounted) return
+    const frame = window.requestAnimationFrame(() => {
+      setConsoleVisible(true)
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [consoleMounted])
+
+  useEffect(() => {
+    if (!consoleMounted || consoleVisible) return
+    const timer = window.setTimeout(() => {
+      setConsoleMounted(false)
+    }, 220)
+    return () => window.clearTimeout(timer)
+  }, [consoleMounted, consoleVisible])
 
   const currentMeta = getThemeSwitchMeta(currentTheme)
   const tierLabels = {
@@ -636,7 +660,11 @@ const ThemeSwitch = () => {
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-950'
               }`}
               onClick={() => {
-                setConsoleVisible(visible => !visible)
+                if (consoleMounted) {
+                  setConsoleVisible(visible => !visible)
+                } else {
+                  setConsoleMounted(true)
+                }
               }}
               title='配置主题'
               aria-label='配置主题'
@@ -661,9 +689,10 @@ const ThemeSwitch = () => {
         </div>
       </Draggable>
 
-      {consoleVisible && (
+      {consoleMounted && (
         <ThemeConsole
           meta={currentMeta}
+          isOpen={consoleVisible}
           onClose={() => {
             setConsoleVisible(false)
           }}

--- a/docs/design/xuhome/DESIGN.md
+++ b/docs/design/xuhome/DESIGN.md
@@ -101,10 +101,13 @@ Cards, buttons and inputs use a restrained 2px radius and visible 2–3px border
 
 Buttons and tags use the same interaction rules: primary backgrounds use `on-primary`, hover backgrounds use `on-primary-hover`, and accent backgrounds use `on-accent`. Text colors must change together with their background state. Hero text uses its custom colors in light mode and the active dark primary/text colors in dark mode.
 
+The theme console behaves like a fast right-side drawer. It enters from just beyond the viewport in 200ms with an ease-out curve and exits before unmounting, so users can visually locate it. Respect `prefers-reduced-motion` by removing the transition.
+
 # Do's and Don'ts
 
 - Do keep body and secondary text light on dark surfaces.
 - Do switch border and hard-shadow colors with the active mode.
 - Do derive button foreground colors whenever a palette background changes.
+- Do animate the theme console from the screen edge instead of making it appear abruptly.
 - Don't hardcode `text-white` for arbitrary user-selected colors.
 - Don't write active light-mode aliases inline; doing so prevents dark-mode CSS from taking effect.


### PR DESCRIPTION
## 变更说明

- 主题设置框从屏幕右侧外快速滑入，帮助用户锁定弹框位置
- 再次点击设置按钮或关闭按钮时先滑出，再卸载组件
- 使用 200ms ease-out 动画，保持快速响应
- 支持 `prefers-reduced-motion`，用户要求减少动态效果时取消过渡
- 增加 dialog 语义和开关状态标记
- 将抽屉动效规则补充到 XuHome `DESIGN.md`

## 验证

- `npx next lint --file components/ThemeSwitch.js`
- `npx jest __tests__/lib/themeColorUtils.test.js __tests__/conf/themeSwitch.xuhome.test.js --runInBand`
- `npx -p @google/design.md designmd lint docs/design/xuhome/DESIGN.md`
- 本地浏览器验证打开、再次点击关闭、最终定位及深浅色样式
