### PR TITLE
fix: skip optimization for static share SVG icons

### DIFF
--- a/__tests__/components/ShareButtons.test.js
+++ b/__tests__/components/ShareButtons.test.js
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'fs'
+import path from 'path'
+
+describe('ShareButtons static export icons', () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), 'components', 'ShareButtons.js'),
+    'utf8'
+  )
+
+  it.each(['/svg/csdn.svg', '/svg/juejin.svg'])(
+    'does not optimize the local %s icon',
+    iconPath => {
+      const iconBlock = source.match(
+        new RegExp(
+          `<Image[\\s\\S]*?src=['"]${iconPath.replaceAll('/', '\\/')}['"][\\s\\S]*?\\/>`
+        )
+      )?.[0]
+
+      expect(iconBlock).toBeTruthy()
+      expect(iconBlock).toContain('unoptimized')
+    }
+  )
+})

--- a/components/ShareButtons.js
+++ b/components/ShareButtons.js
@@ -282,6 +282,7 @@ const ShareButtons = ({ post }) => {
                     height={28}
                     className='w-5 h-5'
                     loading='lazy'
+                    unoptimized
                   />
                 </div>
               </button>
@@ -304,6 +305,7 @@ const ShareButtons = ({ post }) => {
                     height={24}
                     className='w-5 h-5'
                     loading='lazy'
+                    unoptimized
                   />
                 </div>
               </button>


### PR DESCRIPTION
## Summary
- add unoptimized to the CSDN and Juejin share SVG icons
- add a regression test so these local SVG icons do not fall back to Next image optimization in static export

Fixes #4418.

## Verification
- yarn test __tests__/components/ShareButtons.test.js --runInBand
- yarn export
- rg confirmed exported JS no longer contains _next/image requests for /svg/csdn.svg or /svg/juejin.svg