### PR TITLE
docs: document Notion Config inner page URL toggle

### DIFF
--- a/__tests__/lib/config.test.js
+++ b/__tests__/lib/config.test.js
@@ -24,4 +24,12 @@ describe('siteConfig', () => {
       'page'
     )
   })
+
+  it('reads inner page parent path toggle from Notion Config', () => {
+    expect(
+      siteConfig('INNER_PAGE_URL_PARENT_PATH', false, {
+        INNER_PAGE_URL_PARENT_PATH: 'true'
+      })
+    ).toBe(true)
+  })
 })

--- a/docs/user-guide/changelog/latest.md
+++ b/docs/user-guide/changelog/latest.md
@@ -4,11 +4,11 @@
 
 ## 4.10.10 发布要点
 
-`4.10.10` 是一次小版本维护发布，集中收录 `v4.10.9` 之后的近期主线改动。普通站点同步最新 `main` 后重新部署即可；只有需要内嵌子页面层级 URL 的站点，才需要新增可选环境变量。
+`4.10.10` 是一次小版本维护发布，集中收录 `v4.10.9` 之后的近期主线改动。普通站点同步最新 `main` 后重新部署即可；只有需要内嵌子页面层级 URL 的站点，才需要新增可选配置。
 
 ### Notion 内嵌子页面 URL
 
-- 新增可选配置 `NEXT_PUBLIC_INNER_PAGE_URL_PARENT_PATH=true`，让未收录到数据库的 Notion 内嵌子页面 URL 跟随当前文章路径，例如 `/article/fpga-studying-notes/{pageId}`。
+- 新增可选配置，推荐在 Notion Config 中添加 `INNER_PAGE_URL_PARENT_PATH=true`；也可以在部署平台添加 `NEXT_PUBLIC_INNER_PAGE_URL_PARENT_PATH=true`。开启后，未收录到数据库的 Notion 内嵌子页面 URL 会跟随当前文章路径，例如 `/article/fpga-studying-notes/{pageId}`。
 - 已收录到 NotionNext 数据库、并拥有明确 `slug / href` 的页面仍优先跳转自己的正式地址，避免影响 sitemap、RSS、站内搜索和旧链接兼容。
 - 该能力只优化访问路径和层级表达；未收录子页面不会因此自动进入 sitemap、RSS 或搜索索引。需要 SEO 收录的页面仍建议加入主数据库并配置明确 `slug`。
 
@@ -42,7 +42,7 @@
 ### 升级说明
 
 - 普通 Vercel / Netlify / Cloudflare Pages / Docker 站点：同步最新 `main` 后重新部署即可。
-- 如果要启用内嵌子页面父路径 URL，在部署平台添加 `NEXT_PUBLIC_INNER_PAGE_URL_PARENT_PATH=true` 后重新部署。
+- 如果要启用内嵌子页面父路径 URL，推荐在 Notion Config 添加 `INNER_PAGE_URL_PARENT_PATH=true`；也可以在部署平台添加 `NEXT_PUBLIC_INNER_PAGE_URL_PARENT_PATH=true` 后重新部署。
 - 如果你依赖 Docker 镜像，请等待本版本 GitHub Release 对应的 GHCR 镜像发布完成后再拉取。
 
 ### GitHub Release
@@ -70,7 +70,7 @@
 - 分享按钮在移动端改为横向滚动，不再挤压变形。
 - 加密文章提交按钮在多个主题中统一修复，窄屏下不会只显示半个“提交”。
 - 原创存证、公开清单和一键复制证据能力已进入文档化使用路径，适合原创长文站点逐步启用。
-- 内嵌 Notion 子页面可通过 `NEXT_PUBLIC_INNER_PAGE_URL_PARENT_PATH=true` 让未收录子页的访问地址跟随父级文章路径。
+- 内嵌 Notion 子页面可通过 Notion Config 配置 `INNER_PAGE_URL_PARENT_PATH=true`，或通过环境变量 `NEXT_PUBLIC_INNER_PAGE_URL_PARENT_PATH=true`，让未收录子页的访问地址跟随父级文章路径。
 
 ### 主题修复
 

--- a/docs/user-guide/config/url-customize.md
+++ b/docs/user-guide/config/url-customize.md
@@ -109,7 +109,15 @@ POST_URL_PREFIX 配置为： `%category%/%year%/%month%/%day%`
 
 Notion 页面中可以继续嵌套子页面。默认情况下，NotionNext 会优先把能在站点数据库中找到的内页链接转换为该页面自己的 `slug`；如果子页面没有收录到数据库中，则会保留 Notion 页面 ID 作为兜底地址。
 
-如果希望未收录的内嵌子页面 URL 也体现父级文章层级，可以开启：
+如果希望未收录的内嵌子页面 URL 也体现父级文章层级，推荐直接在 Notion Config 配置中心添加一行：
+
+| Key | Value | 说明 |
+| --- | --- | --- |
+| `INNER_PAGE_URL_PARENT_PATH` | `true` | 未收录内嵌子页面 URL 跟随父级文章路径 |
+
+保存 Notion Config 后重新部署或等待站点重新读取配置即可生效。该配置会优先于部署平台环境变量，适合不想修改代码或部署配置的站点。
+
+也可以在部署平台使用环境变量开启：
 
 ```bash
 NEXT_PUBLIC_INNER_PAGE_URL_PARENT_PATH=true

--- a/docs/user-guide/reference/features.md
+++ b/docs/user-guide/reference/features.md
@@ -38,6 +38,7 @@
 | `POSTS_SHARE_SERVICES` | 分享渠道列表 |
 | `ARTICLE_EXPIRATION_*` | 文章过期提示（HEO 等主题） |
 | `TAG_SORT_BY_COUNT` | 标签按文章数排序 |
+| `INNER_PAGE_URL_PARENT_PATH` / `NEXT_PUBLIC_INNER_PAGE_URL_PARENT_PATH` | 未收录内嵌子页面 URL 跟随父级文章路径（4.10.10+） |
 
 ## Notion（conf/notion.config.js）
 

--- a/docs/user-guide/update.md
+++ b/docs/user-guide/update.md
@@ -46,7 +46,13 @@ NotionNext教程
 
 `4.10.10` 是一次小版本维护发布。普通站点同步最新 `main` 后重新部署即可，不需要新增必填环境变量。
 
-如果你希望 Notion 文章中的未收录内嵌子页面 URL 跟随父级文章路径，可以在部署平台添加：
+如果你希望 Notion 文章中的未收录内嵌子页面 URL 跟随父级文章路径，推荐在 Notion Config 配置中心添加：
+
+| Key | Value |
+| --- | --- |
+| `INNER_PAGE_URL_PARENT_PATH` | `true` |
+
+该方式不需要修改代码。也可以在部署平台添加环境变量：
 
 ```bash
 NEXT_PUBLIC_INNER_PAGE_URL_PARENT_PATH=true


### PR DESCRIPTION
## Summary

- Clarify that `INNER_PAGE_URL_PARENT_PATH=true` can be configured directly in Notion Config.
- Keep `NEXT_PUBLIC_INNER_PAGE_URL_PARENT_PATH=true` documented as the deployment-platform environment variable alternative.
- Add the toggle to the feature/config index and cover Notion Config boolean parsing in `siteConfig` tests.

## Verification

- `yarn jest __tests__/lib/config.test.js __tests__/lib/db/notion/convertInnerUrl.test.js --runInBand`
- `git diff --check`
- `yarn docs:site:build`