### PR TITLE
fix(pwa): wrap writePwaManifest in try-catch to prevent build failure

### DIFF
--- a/__tests__/lib/pwa.server.test.js
+++ b/__tests__/lib/pwa.server.test.js
@@ -1,0 +1,77 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+jest.mock('node:fs', () => ({
+  __esModule: true,
+  default: {
+    writeFileSync: jest.fn(),
+    existsSync: jest.fn(),
+    readFileSync: jest.fn()
+  },
+  writeFileSync: jest.fn(),
+  existsSync: jest.fn(),
+  readFileSync: jest.fn()
+}))
+
+describe('PWA manifest error handling', () => {
+  let writePwaManifest
+
+  beforeEach(() => {
+    jest.resetModules()
+    // Set BUILD_MODE so writePwaManifest actually runs
+    process.env.BUILD_MODE = 'true'
+    writePwaManifest = require('@/lib/pwa.server').writePwaManifest
+  })
+
+  afterEach(() => {
+    delete process.env.BUILD_MODE
+    jest.restoreAllMocks()
+  })
+
+  it('does not throw when filesystem is read-only', () => {
+    const fsMock = require('node:fs').default || require('node:fs')
+    fsMock.writeFileSync.mockImplementation(() => {
+      throw new Error('read-only filesystem')
+    })
+
+    // Capture console.warn
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Should not throw
+    expect(() =>
+      writePwaManifest({ siteInfo: { title: 'Test' }, notionConfig: {} })
+    ).not.toThrow()
+
+    // Warning should contain failure reason
+    expect(warnSpy).toHaveBeenCalled()
+    const warnArg = warnSpy.mock.calls[0].join(' ')
+    expect(warnArg).toContain('read-only filesystem')
+
+    warnSpy.mockRestore()
+  })
+
+  it('sets manifestWritten=true on successful write', () => {
+    const fsMock = require('node:fs').default || require('node:fs')
+    fsMock.writeFileSync.mockImplementation(() => {})
+
+    // First call should write successfully
+    expect(() =>
+      writePwaManifest({ siteInfo: { title: 'Test' }, notionConfig: {} })
+    ).not.toThrow()
+
+    // writeFileSync should have been called
+    expect(fsMock.writeFileSync).toHaveBeenCalled()
+  })
+
+  it('skips write when BUILD_MODE is not true', () => {
+    delete process.env.BUILD_MODE
+
+    const fsMock = require('node:fs').default || require('node:fs')
+    fsMock.writeFileSync.mockClear()
+
+    writePwaManifest({ siteInfo: { title: 'Test' }, notionConfig: {} })
+
+    // writeFileSync should not be called when BUILD_MODE !== 'true'
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled()
+  })
+})

--- a/lib/pwa.server.js
+++ b/lib/pwa.server.js
@@ -7,9 +7,13 @@ let manifestWritten = false
 export const writePwaManifest = ({ siteInfo = {}, notionConfig = {} } = {}) => {
   if (manifestWritten || process.env.BUILD_MODE !== 'true') return
 
-  const manifestPath = path.join(process.cwd(), 'public', 'manifest.json')
-  const manifest = buildPwaManifest({ siteInfo, notionConfig })
+  try {
+    const manifestPath = path.join(process.cwd(), 'public', 'manifest.json')
+    const manifest = buildPwaManifest({ siteInfo, notionConfig })
 
-  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
-  manifestWritten = true
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    manifestWritten = true
+  } catch (err) {
+    console.warn('[PWA] Failed to write manifest.json:', err?.message || err)
+  }
 }


### PR DESCRIPTION
## 问题

`writePwaManifest` 使用 `fs.writeFileSync` 直接写入 `public/manifest.json`，在只读文件系统或权限不足时会抛出异常并中断整个构建流程。PWA manifest 写入失败不应阻止站点构建。

## 修复方案

- 将 `fs.writeFileSync` 包裹在 `try-catch` 中，写入失败时仅打印警告而非崩溃
- 新增 `__tests__/lib/pwa.server.test.js`，mock 只读文件系统验证不抛异常

## 测试

- ✅ 244 测试全部通过（含新增 error handling 测试）
- ✅ `yarn build` 成功

## 变更文件

| 文件 | 说明 |
|---|---|
| `lib/pwa.server.js` | try-catch 错误处理 |
| `__tests__/lib/pwa.server.test.js` | 只读文件系统回归测试 |