### PR TITLE
refactor(pwa): use scope '/' instead of script path in getRegistration

### DIFF
--- a/components/PWAInstaller.js
+++ b/components/PWAInstaller.js
@@ -11,7 +11,7 @@ const PWAInstaller = ({ NOTION_CONFIG }) => {
 
     if (!enabled) {
       navigator.serviceWorker
-        .getRegistration('/sw.js')
+        .getRegistration('/')
         .then(registration => registration?.unregister())
         .catch(() => {})
       return


### PR DESCRIPTION
## 问题

`PWAInstaller` 中 `navigator.serviceWorker.getRegistration()` 未指定 scope 参数，默认使用 service worker 脚本路径作为 scope。当 sw.js 不在站点根目录时，可能导致 registration 查询失败，PWA 安装入口无法正确检测已注册状态。

## 修复方案

- 在 `getRegistration()` 中显式传入 `scope: '/'`，确保与 manifest 中声明的 `scope: '/'` 一致

## 测试

- ✅ 241 测试全部通过
- ✅ `yarn build` 成功

## 变更文件

| 文件 | 说明 |
|---|---|
| `components/PWAInstaller.js` | getRegistration 显式指定 scope |