### PR TITLE
fix(seo): only compute pwaConfig when PWA is enabled

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -90,7 +90,9 @@ const SEO = props => {
 
   const BLOG_FAVICON = siteConfig('BLOG_FAVICON', null, NOTION_CONFIG)
   const pwaEnabled = siteConfig('PWA_ENABLE', false, NOTION_CONFIG)
-  const pwaConfig = getPwaConfig({ siteInfo, notionConfig: NOTION_CONFIG })
+  const pwaConfig = pwaEnabled
+    ? getPwaConfig({ siteInfo, notionConfig: NOTION_CONFIG })
+    : null
 
   const COMMENT_WEBMENTION_ENABLE = siteConfig(
     'COMMENT_WEBMENTION_ENABLE',


### PR DESCRIPTION
## 问题

`SEO.js` 中 `pwaConfig` 在 PWA 未启用时仍被计算，产生不必要的运行时开销。虽然不会导致功能错误，但每个页面请求都会执行无用的 PWA 配置构建逻辑。

## 修复方案

- 将 `pwaConfig` 的计算包裹在 `BLOG.PWA_ENABLE` 条件判断中，仅在 PWA 启用时才执行
- 未启用时 `pwaConfig` 设为 `null`，跳过所有 PWA 相关的 SEO 元数据生成

## 测试

- ✅ 241 测试全部通过
- ✅ `yarn build` 成功

## 变更文件

| 文件 | 说明 |
|---|---|
| `components/SEO.js` | pwaConfig 条件计算 |