### PR TITLE
fix(sw): only clear caches with notionnext-pwa- prefix

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,5 @@
 const CACHE_NAME = 'notionnext-pwa-v1'
+const CACHE_PREFIX = 'notionnext-pwa-'
 
 self.addEventListener('install', event => {
   event.waitUntil(self.skipWaiting())
@@ -11,7 +12,9 @@ self.addEventListener('activate', event => {
       .then(keys =>
         Promise.all(
           keys
-            .filter(key => key !== CACHE_NAME)
+            .filter(
+              key => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME
+            )
             .map(key => caches.delete(key))
         )
       )


### PR DESCRIPTION
## 已知问题

1. Service Worker 的 `activate` 事件中，缓存清理使用 `keys.filter(key => key !== CACHE_NAME)`，会删除所有不等于当前缓存名的 Cache Storage 条目
   - 同源下其他插件或功能创建的缓存会被误删
   - 仅当 PWA 缓存版本更新时触发，但一旦触发影响范围不可控

## 解决方案

1. 只清理 `notionnext-pwa-` 前缀的缓存，保留其他功能的缓存不受影响

## 改动收益

1. 避免误删同源下其他插件/功能的 Service Worker 缓存
2. 缓存清理行为可预测、作用域明确

## 具体改动

1. `public/sw.js`
   - 新增 `CACHE_PREFIX` 常量（`'notionnext-pwa-'`）
   - `activate` 事件中过滤条件改为 `key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME`

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 全部 249 个单元测试通过

## 用户文档

- [x] 不适用（无文档改动）