### PR TITLE
fix(convertInnerUrl): strip query params and hash before ID extraction

### DIFF
--- a/__tests__/lib/db/notion/convertInnerUrl.test.js
+++ b/__tests__/lib/db/notion/convertInnerUrl.test.js
@@ -114,4 +114,57 @@ describe('convertInnerUrl', () => {
       '/article/parent-post/4aea95fb3fd5fcf81846aaaaaaaaaaaa'
     )
   })
+
+  it('strips query params before extracting Notion ID', () => {
+    // Notion URLs often include ?pvs=4 which must not break ID extraction
+    document.body.innerHTML = `
+      <div id="notion-article">
+        <a class="notion-link" href="https://www.notion.so/4aea95fb3fd5fcf81846aaaaaaaaaaaa?pvs=4" target="_blank">Links</a>
+      </div>
+    `
+
+    convertInnerUrl({
+      allPages: [
+        {
+          title: 'Links',
+          type: 'Page',
+          href: '/links',
+          slug: 'links',
+          short_id: 'fcf8-1846-aaaaaaaaaaaa'
+        }
+      ],
+      lang: undefined
+    })
+
+    expect(document.querySelector('a.notion-link')).toHaveAttribute(
+      'href',
+      '/links'
+    )
+  })
+
+  it('strips hash fragment before extracting Notion ID', () => {
+    document.body.innerHTML = `
+      <div id="notion-article">
+        <a class="notion-link" href="https://www.notion.so/4aea95fb3fd5fcf81846aaaaaaaaaaaa#section" target="_blank">Links</a>
+      </div>
+    `
+
+    convertInnerUrl({
+      allPages: [
+        {
+          title: 'Links',
+          type: 'Page',
+          href: '/links',
+          slug: 'links',
+          short_id: 'fcf8-1846-aaaaaaaaaaaa'
+        }
+      ],
+      lang: undefined
+    })
+
+    expect(document.querySelector('a.notion-link')).toHaveAttribute(
+      'href',
+      '/links'
+    )
+  })
 })

--- a/lib/db/notion/convertInnerUrl.js
+++ b/lib/db/notion/convertInnerUrl.js
@@ -30,7 +30,15 @@ export const convertInnerUrl = ({
     // url替换成slug
     if (anchorTag?.href) {
       // 如果url是一个Notion_id，尝试匹配成博客的文章内链
-      const slug = getLastPartOfUrl(anchorTag.href)
+      // 先去除查询参数和 hash，避免 ?pvs=4 等后缀干扰 ID 提取
+      let hrefPath = anchorTag.href
+      try {
+        hrefPath = new URL(anchorTag.href).pathname
+      } catch (_) {
+        // 非标准 URL，回退到手动去 query/hash
+        hrefPath = anchorTag.href.split('?')[0].split('#')[0]
+      }
+      const slug = getLastPartOfUrl(hrefPath)
       if (checkStrIsNotionId(slug)) {
         const slugPage = allPages?.find(page => {
           return idToUuid(slug).indexOf(page.short_id) === 14


### PR DESCRIPTION
## 已知问题

1. Notion 页面链接常带有查询参数（如 `?pvs=4`）或 hash 片段（如 `#section`）
   - `convertInnerUrl` 中 `getLastPartOfUrl(anchorTag.href)` 对含 `?pvs=4` 的 URL 返回 `页面ID?pvs=4`
   - `checkStrIsNotionId()` 对 `页面ID?pvs=4` 返回 false，导致内链转换失效
   - 用户从 Notion 点击带参数的链接时无法跳转到对应站内文章

## 解决方案

1. 在提取 ID 前先用 `new URL().pathname` 去除查询参数和 hash
   - 对非标准 URL 回退到手动 `split('?')[0].split('#')[0]`

## 改动收益

1. 带 `?pvs=4` 等 Notion 查询参数的内链可正确转换为站内文章链接
2. 带 hash 片段的链接同样正确处理

## 具体改动

1. `lib/db/notion/convertInnerUrl.js`
   - ID 提取前先解析 URL pathname，去除 query/hash
2. `__tests__/lib/db/notion/convertInnerUrl.test.js`
   - 新增 2 个回归测试：`?pvs=4` 参数和 `#hash` 片段

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 全部 251 个单元测试通过（含 2 个新增测试）

## 用户文档

- [x] 不适用（无文档改动）