### PR TITLE
fix(pwa): improve service worker registration lifecycle

### DIFF
--- a/__tests__/components/PWAInstaller.test.js
+++ b/__tests__/components/PWAInstaller.test.js
@@ -1,0 +1,73 @@
+jest.mock('@/lib/config', () => ({
+  siteConfig: (_key, defaultValue, notionConfig) => {
+    if (notionConfig && notionConfig.PWA_ENABLE !== undefined) {
+      return notionConfig.PWA_ENABLE
+    }
+    return defaultValue
+  },
+}))
+
+import { render, act } from '@testing-library/react'
+import PWAInstaller from '@/components/PWAInstaller'
+
+describe('PWAInstaller', () => {
+  let getRegistrationMock
+  let registerMock
+  let unregisterMock
+  let resolveGetRegistration
+
+  beforeEach(() => {
+    unregisterMock = jest.fn()
+    registerMock = jest.fn().mockResolvedValue(undefined)
+
+    // Deferred promise so we can control when getRegistration resolves
+    resolveGetRegistration = null
+    const registrationPromise = new Promise(resolve => {
+      resolveGetRegistration = resolve
+    })
+    getRegistrationMock = jest.fn().mockReturnValue(registrationPromise)
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        getRegistration: getRegistrationMock,
+        register: registerMock,
+      },
+    })
+  })
+
+  it('does not unregister when switching from disabled to enabled before getRegistration resolves', async () => {
+    // Step 1: render with PWA disabled — triggers getRegistration()
+    const { rerender } = render(<PWAInstaller NOTION_CONFIG={{ PWA_ENABLE: false }} />)
+
+    expect(getRegistrationMock).toHaveBeenCalledWith('/sw.js')
+    expect(unregisterMock).not.toHaveBeenCalled()
+
+    // Step 2: switch to enabled before getRegistration resolves
+    // Cleanup of the disabled effect sets cancelled = true,
+    // then the enabled effect registers the SW.
+    rerender(<PWAInstaller NOTION_CONFIG={{ PWA_ENABLE: true }} />)
+
+    expect(registerMock).toHaveBeenCalledWith('/sw.js', { scope: '/' })
+
+    // Step 3: resolve the pending getRegistration promise
+    // cancelled flag should prevent unregister from being called
+    await act(async () => {
+      resolveGetRegistration({ unregister: unregisterMock })
+      await Promise.resolve()
+    })
+
+    expect(unregisterMock).not.toHaveBeenCalled()
+  })
+
+  it('unregisters existing service worker when PWA is disabled', async () => {
+    render(<PWAInstaller NOTION_CONFIG={{ PWA_ENABLE: false }} />)
+
+    await act(async () => {
+      resolveGetRegistration({ unregister: unregisterMock })
+      await Promise.resolve()
+    })
+
+    expect(unregisterMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/components/PWAInstaller.js
+++ b/components/PWAInstaller.js
@@ -9,21 +9,38 @@ const PWAInstaller = ({ NOTION_CONFIG }) => {
       return
     }
 
+    let cancelled = false
+    let loadHandler
+
     if (!enabled) {
       navigator.serviceWorker
         .getRegistration('/sw.js')
-        .then(registration => registration?.unregister())
+        .then(registration => {
+          if (!cancelled) return registration?.unregister()
+        })
         .catch(() => {})
-      return
+
+      return () => {
+        cancelled = true
+      }
     }
 
-    window.addEventListener(
-      'load',
-      () => {
-        navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {})
-      },
-      { once: true }
-    )
+    const register = () => {
+      if (cancelled) return
+      navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {})
+    }
+
+    if (document.readyState === 'complete') {
+      register()
+    } else {
+      loadHandler = register
+      window.addEventListener('load', loadHandler, { once: true })
+    }
+
+    return () => {
+      cancelled = true
+      if (loadHandler) window.removeEventListener('load', loadHandler)
+    }
   }, [enabled])
 
   return null


### PR DESCRIPTION
## 已知问题

1. PWAInstaller 组件的 Service Worker 注册生命周期存在多个问题：
   - 页面已加载完成时仍等待 `load` 事件，注册延迟无意义
   - 组件卸载后 `load` 回调仍可能执行，缺少取消机制
   - PWA 从关闭切换为开启时，旧的 `getRegistration().then()` 可能注销刚注册的 SW（竞态）
   - `!enabled` 分支未返回 cleanup 函数，`cancelled` 标志无法生效

## 解决方案

1. `document.readyState === 'complete'` 时立即注册，不再等待 `load`
2. 所有异步回调内部检查 `cancelled` 标志
3. `!enabled` 分支返回 `() => { cancelled = true }` 作为 cleanup
4. PWA 关闭时注销已存在的 Service Worker

## 改动收益

1. 页面已加载时 SW 注册无延迟
2. 组件卸载后不会执行残留异步操作
3. 消除 disabled→enabled 切换时的竞态，SW 不会被误注销

## 具体改动

1. `components/PWAInstaller.js`
   - `!enabled` 分支：`.then()` 内检查 `cancelled`，返回 cleanup
   - `enabled` 分支：`readyState === 'complete'` 时立即注册
2. `__tests__/components/PWAInstaller.test.js`（新增）
   - disabled→enabled 竞态回归测试
   - 正常注销测试

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 全部 251 个单元测试通过（含 2 个新增测试）

## 用户文档

- [x] 不适用（无文档改动）