### PR TITLE
fix(pwa.server): skip manifest write when PWA is disabled

### DIFF
--- a/__tests__/lib/pwa.server.test.js
+++ b/__tests__/lib/pwa.server.test.js
@@ -1,0 +1,115 @@
+jest.mock('node:fs', () => ({
+  writeFileSync: jest.fn(),
+}))
+jest.mock('node:path', () => ({
+  join: jest.fn((...args) => args.join('/')),
+}))
+
+// Helper: get fresh module references with reset state
+function getFreshModule() {
+  jest.resetModules()
+  const fs = require('node:fs')
+  const { writePwaManifest } = require('@/lib/pwa.server')
+  return { fs, writePwaManifest }
+}
+
+describe('writePwaManifest', () => {
+  beforeEach(() => {
+    process.env.BUILD_MODE = 'true'
+  })
+
+  afterEach(() => {
+    delete process.env.BUILD_MODE
+  })
+
+  it('does not write when BUILD_MODE is not true', () => {
+    process.env.BUILD_MODE = 'false'
+    const { fs, writePwaManifest } = getFreshModule()
+    writePwaManifest({ siteInfo: {}, notionConfig: { PWA_ENABLE: true } })
+    expect(fs.writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('does not write when PWA is disabled', () => {
+    const { fs, writePwaManifest } = getFreshModule()
+    writePwaManifest({ siteInfo: {}, notionConfig: { PWA_ENABLE: false } })
+    expect(fs.writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('writes when PWA is enabled via boolean true', () => {
+    const { fs, writePwaManifest } = getFreshModule()
+    writePwaManifest({
+      siteInfo: { title: 'Test' },
+      notionConfig: { PWA_ENABLE: true },
+    })
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes when PWA is enabled via string "true"', () => {
+    const { fs, writePwaManifest } = getFreshModule()
+    writePwaManifest({
+      siteInfo: { title: 'Test' },
+      notionConfig: { PWA_ENABLE: 'true' },
+    })
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes when PWA is enabled via string "yes"', () => {
+    const { fs, writePwaManifest } = getFreshModule()
+    writePwaManifest({
+      siteInfo: { title: 'Test' },
+      notionConfig: { PWA_ENABLE: 'yes' },
+    })
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes when PWA is enabled via string "on"', () => {
+    const { fs, writePwaManifest } = getFreshModule()
+    writePwaManifest({
+      siteInfo: { title: 'Test' },
+      notionConfig: { PWA_ENABLE: 'on' },
+    })
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes when PWA is enabled via number 1', () => {
+    const { fs, writePwaManifest } = getFreshModule()
+    writePwaManifest({
+      siteInfo: { title: 'Test' },
+      notionConfig: { PWA_ENABLE: 1 },
+    })
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not write when PWA_ENABLE is "false" string', () => {
+    const { fs, writePwaManifest } = getFreshModule()
+    writePwaManifest({
+      siteInfo: { title: 'Test' },
+      notionConfig: { PWA_ENABLE: 'false' },
+    })
+    expect(fs.writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('falls back to BLOG.PWA_ENABLE when notionConfig has no PWA_ENABLE', () => {
+    // BLOG.PWA_ENABLE is false by default in blog.config.js
+    const { fs, writePwaManifest } = getFreshModule()
+    writePwaManifest({
+      siteInfo: { title: 'Test' },
+      notionConfig: {},
+    })
+    expect(fs.writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('respects explicit false in notionConfig over BLOG fallback', () => {
+    // Even if BLOG.PWA_ENABLE were true, explicit false in notionConfig wins
+    jest.resetModules()
+    jest.doMock('@/blog.config', () => ({ PWA_ENABLE: true }))
+    const fs = require('node:fs')
+    const { writePwaManifest } = require('@/lib/pwa.server')
+    writePwaManifest({
+      siteInfo: { title: 'Test' },
+      notionConfig: { PWA_ENABLE: false },
+    })
+    expect(fs.writeFileSync).not.toHaveBeenCalled()
+    jest.dontMock('@/blog.config')
+  })
+})

--- a/lib/pwa.server.js
+++ b/lib/pwa.server.js
@@ -1,11 +1,24 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import BLOG from '@/blog.config'
 import { buildPwaManifest } from './pwa'
 
 let manifestWritten = false
 
+const isPwaEnabled = value => {
+  if (value === true || value === 1) return true
+  if (typeof value !== 'string') return false
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
 export const writePwaManifest = ({ siteInfo = {}, notionConfig = {} } = {}) => {
-  if (manifestWritten || process.env.BUILD_MODE !== 'true') return
+  if (
+    manifestWritten ||
+    process.env.BUILD_MODE !== 'true' ||
+    !isPwaEnabled(notionConfig?.PWA_ENABLE ?? BLOG.PWA_ENABLE)
+  ) {
+    return
+  }
 
   const manifestPath = path.join(process.cwd(), 'public', 'manifest.json')
   const manifest = buildPwaManifest({ siteInfo, notionConfig })


### PR DESCRIPTION
## 已知问题

1. `writePwaManifest` 在构建时无条件写入 `manifest.json`，不检查 `PWA_ENABLE` 开关
   - PWA 被显式关闭时仍会覆盖已有的 manifest 文件
   - 仅接受布尔 `true`，不支持字符串 `'true'`/`'yes'`/`'on'` 等常见配置值

## 解决方案

1. 写入前检查 `isPwaEnabled()`，PWA 关闭时跳过
2. 兼容多种 truthy 值：`true`、`1`、`'1'`、`'true'`、`'yes'`、`'on'`
3. 优先使用 Notion Config 的 `PWA_ENABLE`，用 `??`（nullish coalescing）回退到 `BLOG.PWA_ENABLE`，保留显式 `false`

## 改动收益

1. PWA 关闭时不会覆盖已有 manifest
2. 配置更灵活，支持字符串/数字等多种开关写法
3. Notion Config 显式 `false` 不会被 BLOG fallback 覆盖

## 具体改动

1. `lib/pwa.server.js`
   - 新增 `isPwaEnabled()` 辅助函数
   - 写入条件增加 PWA enable 检查
   - 配置读取改为 `notionConfig?.PWA_ENABLE ?? BLOG.PWA_ENABLE`
2. `__tests__/lib/pwa.server.test.js`（新增）
   - 10 个单元测试：enable/disable 各路径 + BLOG fallback + 显式 false 优先

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 全部 259 个单元测试通过（含 10 个新增测试）

## 用户文档

- [x] 不适用（无文档改动）