### PR TITLE
fix: update footer links to organization repository

### DIFF
--- a/components/PoweredBy.js
+++ b/components/PoweredBy.js
@@ -9,7 +9,7 @@ export default function PoweredBy(props) {
     <div className={`inline text-sm font-serif ${props.className || ''}`}>
       <span className='mr-1'>Powered by</span>
       <a
-        href='https://github.com/tangly1024/NotionNext'
+        href='https://github.com/notionnext-org/NotionNext'
         className='underline justify-start'>
         NotionNext {siteConfig('VERSION')}
       </a>

--- a/themes/commerce/components/Footer.js
+++ b/themes/commerce/components/Footer.js
@@ -204,7 +204,7 @@ const Footer = props => {
             <div className='text-xs text-light-500 dark:text-gray-700'>
               Powered by{' '}
               <a
-                href='https://github.com/tangly1024/NotionNext'
+                href='https://github.com/notionnext-org/NotionNext'
                 className='dark:text-gray-300'>
                 NotionNext {siteConfig('VERSION')}
               </a>

--- a/themes/fukasawa/components/SiteInfo.js
+++ b/themes/fukasawa/components/SiteInfo.js
@@ -41,7 +41,7 @@ function SiteInfo({ title }) {
         <span className='text-xs font-serif'>
           Powered by
           <a
-            href='https://github.com/tangly1024/NotionNext'
+            href='https://github.com/notionnext-org/NotionNext'
             className='underline'>
             NotionNext {siteConfig('VERSION')}
           </a>

--- a/themes/fuwari/components/Footer.js
+++ b/themes/fuwari/components/Footer.js
@@ -19,7 +19,7 @@ const Footer = () => {
         <p className='mt-1'>
           Powered by{' '}
           <a
-            href='https://github.com/tangly1024/NotionNext'
+            href='https://github.com/notionnext-org/NotionNext'
             target='_blank'
             rel='noopener noreferrer'
             className='fuwari-link font-semibold'>

--- a/themes/game/components/Footer.js
+++ b/themes/game/components/Footer.js
@@ -21,7 +21,7 @@ export const Footer = props => {
         <span className='dark:text-gray-200 no-underline ml-4'>
           Powered by
           <a
-            href='https://github.com/tangly1024/NotionNext'
+            href='https://github.com/notionnext-org/NotionNext'
             className=' hover:underline'>
             {' '}
             NotionNext {siteConfig('VERSION')}{' '}

--- a/themes/gitbook/components/Footer.js
+++ b/themes/gitbook/components/Footer.js
@@ -52,7 +52,7 @@ const Footer = ({ siteInfo }) => {
       <div className='text-xs font-serif'>
         Powered By{' '}
         <a
-          href='https://github.com/tangly1024/NotionNext'
+          href='https://github.com/notionnext-org/NotionNext'
           className='underline text-gray-500 dark:text-gray-300'>
           NotionNext {siteConfig('VERSION')}
         </a>

--- a/themes/landing/components/Footer.js
+++ b/themes/landing/components/Footer.js
@@ -151,7 +151,7 @@ export default function Footer() {
                     <ul className="flex mb-4 md:order-1 md:ml-4 md:mb-0">
                         <li>
                           <div className='h-full flex justify-center items-center text-gray-600 hover:text-gray-900 bg-white hover:bg-white-100'>
-                             Powered by<a href='https://github.com/tangly1024/NotionNext' className='mx-1 hover:underline font-semibold'>NotionNext {siteConfig('VERSION')}</a>
+                             Powered by<a href='https://github.com/notionnext-org/NotionNext' className='mx-1 hover:underline font-semibold'>NotionNext {siteConfig('VERSION')}</a>
                           </div>
                         </li>
                         {/* <li>

--- a/themes/matery/components/Footer.js
+++ b/themes/matery/components/Footer.js
@@ -51,7 +51,7 @@ const Footer = ({ title }) => {
         <span className='text-xs '>
           Powered by{' '}
           <a
-            href='https://github.com/tangly1024/NotionNext'
+            href='https://github.com/notionnext-org/NotionNext'
             className='underline dark:text-gray-300'>
             NotionNext {siteConfig('VERSION')}
           </a>

--- a/themes/medium/components/Footer.js
+++ b/themes/medium/components/Footer.js
@@ -44,7 +44,7 @@ const Footer = ({ title }) => {
         <span className='text-xs font-serif'>
           Powered by
           <a
-            href='https://github.com/tangly1024/NotionNext'
+            href='https://github.com/notionnext-org/NotionNext'
             className='underline text-gray-500 dark:text-gray-300'>
             NotionNext {siteConfig('VERSION')}
           </a>

--- a/themes/movie/components/Footer.js
+++ b/themes/movie/components/Footer.js
@@ -36,7 +36,7 @@ export const Footer = props => {
           <span className='dark:text-gray-200 no-underline ml-4'>
             Powered by
             <a
-              href='https://github.com/tangly1024/NotionNext'
+              href='https://github.com/notionnext-org/NotionNext'
               className=' hover:underline'>
               NotionNext {siteConfig('VERSION')}
             </a>

--- a/themes/nav/components/Footer.js
+++ b/themes/nav/components/Footer.js
@@ -28,7 +28,7 @@ const Footer = ({ siteInfo }) => {
       <div className='text-xs font-serif py-1'>
         Powered By{' '}
         <a
-          href='https://github.com/tangly1024/NotionNext'
+          href='https://github.com/notionnext-org/NotionNext'
           className='underline text-gray-500 dark:text-gray-300'>
           NotionNext {siteConfig('VERSION')}
         </a>

--- a/themes/next/components/Footer.js
+++ b/themes/next/components/Footer.js
@@ -44,7 +44,7 @@ const Footer = ({ title }) => {
         <span className='text-xs font-serif  text-gray-500 dark:text-gray-300 '>
           Powered by{' '}
           <a
-            href='https://github.com/tangly1024/NotionNext'
+            href='https://github.com/notionnext-org/NotionNext'
             className='underline '>
             NotionNext {siteConfig('VERSION')}
           </a>

--- a/themes/photo/components/Footer.js
+++ b/themes/photo/components/Footer.js
@@ -36,7 +36,7 @@ export const Footer = props => {
           <span className='dark:text-gray-200 no-underline ml-4'>
             Powered by
             <a
-              href='https://github.com/tangly1024/NotionNext'
+              href='https://github.com/notionnext-org/NotionNext'
               className=' hover:underline'>
               NotionNext {siteConfig('VERSION')}
             </a>

--- a/themes/plog/components/Footer.js
+++ b/themes/plog/components/Footer.js
@@ -12,7 +12,7 @@ export const Footer = (props) => {
      <div className="my-4 text-sm leading-6">
        <div className="flex align-baseline justify-start flex-wrap space-x-6">
          <div> © {siteConfig('AUTHOR')} {copyrightDate}  </div>
-         <div>Powered By <a href="https://github.com/tangly1024/NotionNext" className='underline'>NotionNext {siteConfig('VERSION')}</a></div>
+         <div>Powered By <a href="https://github.com/notionnext-org/NotionNext" className='underline'>NotionNext {siteConfig('VERSION')}</a></div>
          <Vercel />
        </div>
      </div>

--- a/themes/simple/components/Footer.js
+++ b/themes/simple/components/Footer.js
@@ -37,7 +37,7 @@ export default function Footer(props) {
           <span className='no-underline ml-4'>
             Powered by
             <a
-              href='https://github.com/tangly1024/NotionNext'
+              href='https://github.com/notionnext-org/NotionNext'
               className=' hover:underline'>
               NotionNext {siteConfig('VERSION')}
             </a>


### PR DESCRIPTION
## Summary

- update visible versioned footer links to the canonical organization repository
- cover the shared footer and theme-specific footer or site-info implementations
- leave historical documentation, example configuration, and unrelated repository URLs unchanged

Fixes #4442

## Verification

- `yarn lint` (passes with existing warnings)
- `yarn type-check`
- `yarn test --runInBand` (50 suites, 263 tests)
- focused inventory confirms all 15 versioned footer links use the canonical URL
- `git diff --check`

## Documentation

Not applicable: this corrects existing repository link targets without changing configuration, usage, or visible behavior.