### PR TITLE
fix(vercel): preserve .html site verification URLs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "cleanUrls": true,
+  "cleanUrls": false,
   "trailingSlash": false,
   "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_MESSAGE\" in *\"[skip-version]\"*) exit 0;; *) exit 1;; esac",
   "headers": []


### PR DESCRIPTION
## Problem
Vercel's global `cleanUrls: true` redirects root-level `.html` verification files with HTTP 308. Search-engine site verification services expect the original URL to return HTTP 200 and preserve the `.html` suffix.

## What this PR changes
- Disable Vercel's global clean-URL redirect.
- Keep the existing Next.js `/:path*.html` rewrite for legacy article URL compatibility.

This fixes the generic site-verification failure reported in #4439 without adding provider-specific routing or changing application routes.

Closes #4439
