### PR TITLE
chore: update legacy repository references after organization migration

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -22,7 +22,7 @@ jobs:
         id: sync
         uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
         with:
-          upstream_sync_repo: tangly1024/NotionNext
+          upstream_sync_repo: notionnext-org/NotionNext
           upstream_sync_branch: main
           target_sync_branch: main
           target_repo_token: ${{ secrets.GITHUB_TOKEN }} # automatically generated, no need to set

--- a/conf/analytics.config.js
+++ b/conf/analytics.config.js
@@ -2,7 +2,7 @@
  * 站点统计插件
  */
 module.exports = {
-  ANALYTICS_VERCEL: process.env.NEXT_PUBLIC_ANALYTICS_VERCEL || false, // vercel自带的统计 https://vercel.com/docs/concepts/analytics/quickstart https://github.com/tangly1024/NotionNext/issues/897
+  ANALYTICS_VERCEL: process.env.NEXT_PUBLIC_ANALYTICS_VERCEL || false, // vercel自带的统计 https://vercel.com/docs/concepts/analytics/quickstart https://github.com/notionnext-org/NotionNext/issues/897
   ANALYTICS_BUSUANZI_ENABLE:
     process.env.NEXT_PUBLIC_ANALYTICS_BUSUANZI_ENABLE || true, // 展示网站阅读量、访问数 see http://busuanzi.ibruce.info/
   ANALYTICS_BAIDU_ID: process.env.NEXT_PUBLIC_ANALYTICS_BAIDU_ID || '', // e.g 只需要填写百度统计的id，[baidu_id] -> https://hm.baidu.com/hm.js?[baidu_id]

--- a/conf/comment.config.js
+++ b/conf/comment.config.js
@@ -29,10 +29,10 @@ module.exports = {
 
   // utterance
   COMMENT_UTTERRANCES_REPO:
-    process.env.NEXT_PUBLIC_COMMENT_UTTERRANCES_REPO || '', // 你的代码仓库名， 例如我是 'tangly1024/NotionNext'； 更多文档参考 https://utteranc.es/
+    process.env.NEXT_PUBLIC_COMMENT_UTTERRANCES_REPO || '', // 你的代码仓库名， 例如我是 'notionnext-org/NotionNext'； 更多文档参考 https://utteranc.es/
 
   // giscus @see https://giscus.app/
-  COMMENT_GISCUS_REPO: process.env.NEXT_PUBLIC_COMMENT_GISCUS_REPO || '', // 你的Github仓库名 e.g 'tangly1024/NotionNext'
+  COMMENT_GISCUS_REPO: process.env.NEXT_PUBLIC_COMMENT_GISCUS_REPO || '', // 你的Github仓库名 e.g 'notionnext-org/NotionNext'
   COMMENT_GISCUS_REPO_ID: process.env.NEXT_PUBLIC_COMMENT_GISCUS_REPO_ID || '', // 你的Github Repo ID e.g ( 設定完 giscus 即可看到 )
   COMMENT_GISCUS_CATEGORY:
     process.env.NEXT_PUBLIC_COMMENT_GISCUS_CATEGORY || '', // 你的Github Discussions 內的 Category 名称 e.g 'General' ( 設定完 giscus 即可看到 )

--- a/conf/comment.config.js
+++ b/conf/comment.config.js
@@ -29,10 +29,10 @@ module.exports = {
 
   // utterance
   COMMENT_UTTERRANCES_REPO:
-    process.env.NEXT_PUBLIC_COMMENT_UTTERRANCES_REPO || '', // 你的代码仓库名， 例如我是 'notionnext-org/NotionNext'； 更多文档参考 https://utteranc.es/
+    process.env.NEXT_PUBLIC_COMMENT_UTTERRANCES_REPO || '', // 你的代码仓库名， 例如 'username/repository'； 更多文档参考 https://utteranc.es/
 
   // giscus @see https://giscus.app/
-  COMMENT_GISCUS_REPO: process.env.NEXT_PUBLIC_COMMENT_GISCUS_REPO || '', // 你的Github仓库名 e.g 'notionnext-org/NotionNext'
+  COMMENT_GISCUS_REPO: process.env.NEXT_PUBLIC_COMMENT_GISCUS_REPO || '', // 你的Github仓库名 e.g 'username/repository'
   COMMENT_GISCUS_REPO_ID: process.env.NEXT_PUBLIC_COMMENT_GISCUS_REPO_ID || '', // 你的Github Repo ID e.g ( 設定完 giscus 即可看到 )
   COMMENT_GISCUS_CATEGORY:
     process.env.NEXT_PUBLIC_COMMENT_GISCUS_CATEGORY || '', // 你的Github Discussions 內的 Category 名称 e.g 'General' ( 設定完 giscus 即可看到 )

--- a/docs/developer/UPDATE.md
+++ b/docs/developer/UPDATE.md
@@ -25,7 +25,7 @@
 
 ```
 GitHub Fork Repository
-├── main (同步 tangly1024/NotionNext)
+├── main (同步 notionnext-org/NotionNext)
 ├── deploy (生产分支 → Vercel)
 └── feature/* (开发分支)
 ```
@@ -49,7 +49,7 @@ GitHub Fork Repository
 
 ```bash
 # 添加上游仓库
-git remote add upstream https://github.com/tangly1024/NotionNext.git
+git remote add upstream https://github.com/notionnext-org/NotionNext.git
 
 # 验证配置
 git remote -v
@@ -59,8 +59,8 @@ git remote -v
 ```
 origin    https://github.com/[你的用户名]/NotionNext.git (fetch)
 origin    https://github.com/[你的用户名]/NotionNext.git (push)
-upstream  https://github.com/tangly1024/NotionNext.git (fetch)
-upstream  https://github.com/tangly1024/NotionNext.git (push)
+upstream  https://github.com/notionnext-org/NotionNext.git (fetch)
+upstream  https://github.com/notionnext-org/NotionNext.git (push)
 ```
 
 > ⚠️ 如果没有看到 upstream 行，说明上游仓库未成功添加
@@ -264,7 +264,7 @@ git push origin deploy
 
 ## 相关资源
 
-- [NotionNext 官方仓库](https://github.com/tangly1024/NotionNext)
+- [NotionNext 官方仓库](https://github.com/notionnext-org/NotionNext)
 - [NotionNext 文档](/user-guide/intro)
 - [Vercel 文档](https://vercel.com/docs)
 

--- a/docs/developer/themes/ENDSPACE.en.md
+++ b/docs/developer/themes/ENDSPACE.en.md
@@ -1,6 +1,6 @@
 ﻿# Endspace Theme (NotionNext)
 
-Endspace is a NotionNext theme inspired by the visual language of *Arknights: Endfield*’s official site, maintained by the community. Upstream repository: [cloud-oc/endspace](https://github.com/cloud-oc/endspace). Tracking issue: [#3990](https://github.com/tangly1024/NotionNext/issues/3990).
+Endspace is a NotionNext theme inspired by the visual language of *Arknights: Endfield*’s official site, maintained by the community. Upstream repository: [cloud-oc/endspace](https://github.com/cloud-oc/endspace). Tracking issue: [#3990](https://github.com/notionnext-org/NotionNext/issues/3990).
 
 **Original author / upstream**: [@cloud-oc](https://github.com/cloud-oc) ([cloud-oc/endspace](https://github.com/cloud-oc/endspace)).
 

--- a/docs/developer/themes/ENDSPACE.md
+++ b/docs/developer/themes/ENDSPACE.md
@@ -1,6 +1,6 @@
 ﻿# Endspace 主题（NotionNext）
 
-Endspace 是受《明日方舟：终末地》官网视觉风格启发的 NotionNext 主题，由社区作者维护；上游仓库见 [cloud-oc/endspace](https://github.com/cloud-oc/endspace)。收录相关讨论见 [Issue #3990](https://github.com/tangly1024/NotionNext/issues/3990)。
+Endspace 是受《明日方舟：终末地》官网视觉风格启发的 NotionNext 主题，由社区作者维护；上游仓库见 [cloud-oc/endspace](https://github.com/cloud-oc/endspace)。收录相关讨论见 [Issue #3990](https://github.com/notionnext-org/NotionNext/issues/3990)。
 
 **原作者 / 上游**：[@cloud-oc](https://github.com/cloud-oc)（仓库 [cloud-oc/endspace](https://github.com/cloud-oc/endspace)）。
 

--- a/docs/user-guide/analytics/clarity.md
+++ b/docs/user-guide/analytics/clarity.md
@@ -73,7 +73,7 @@ Clarity is a free user behavior analytics tool that helps you understand how use
 
 ## 配置NotionNext
 
-对应的配置文件在[blog.config.js：356行](https://github.com/tangly1024/NotionNext/blob/eced20bfe7af015d69eef147af104df4c3ae88ee/blog.config.js#L356)，在NotionNext项目后台添加如下环境变量即可
+对应的配置文件在[blog.config.js：356行](https://github.com/notionnext-org/NotionNext/blob/eced20bfe7af015d69eef147af104df4c3ae88ee/blog.config.js#L356)，在NotionNext项目后台添加如下环境变量即可
 
 您可以在blog.config.js 或者在 vercel环境变量，或者直接在notion-config中配置
 

--- a/docs/user-guide/comments/valine.md
+++ b/docs/user-guide/comments/valine.md
@@ -102,7 +102,7 @@ valine没有自带后台，可以借助 [Valine-Admin](https://github.com/Desert
   - 可能是Vercel后台没有配置Valine/Waline的环境变量，配置后需要redeploy
 
 1. 评论出现 ‘Unexpected end of JSON input’
-配置的Waline地址有误，检查一下，参考此[issue](https://github.com/tangly1024/NotionNext/issues/308)的回答
+配置的Waline地址有误，检查一下，参考此[issue](https://github.com/notionnext-org/NotionNext/issues/308)的回答
 
 1. 评论出现错误提示 ‘fail to fetch’ 或者 ‘Network Error’
 可能是Vercel部署的Waline出现了跨域网络限制，按F12打开控制台，查看是否有打印“缺少CORS头“，相关的错误提示。

--- a/docs/user-guide/comments/waline.md
+++ b/docs/user-guide/comments/waline.md
@@ -67,7 +67,7 @@ Valine和Waline两个插件均要借助LeanCloud提供的云函数，云数据�
 ![Untitled](/legacy/476b942890765788.png)
 ::: tip 提示
 注意：
-如果你使用 LeanCloud 国内版，请额外配置 `LEAN_SERVER` 环境变量，值为你绑定好的域名。否则可能会提示错误：”`serverURL option is required for apps from CN region`“，[详见此ISSUE](https://github.com/tangly1024/NotionNext/issues/308#issuecomment-1157330084)。
+如果你使用 LeanCloud 国内版，请额外配置 `LEAN_SERVER` 环境变量，值为你绑定好的域名。否则可能会提示错误：”`serverURL option is required for apps from CN region`“，[详见此ISSUE](https://github.com/notionnext-org/NotionNext/issues/308#issuecomment-1157330084)。
     - 最后要`redeploy`这个项目使配置生效。
 ![Untitled](/legacy/4ef8e75bf93a31c6.png)
 :::

--- a/docs/user-guide/config-site.md
+++ b/docs/user-guide/config-site.md
@@ -76,8 +76,8 @@ NEXT_PUBLIC_WIDGET_PET_SWITCH_THEME=false
 
 1. 您可以在`blog.config.js`以及各个主题的`config.js`中找到支持的配置，在4.8.0之后的版本，为了减少`blog.config.js`的体积，不同模块的配置被拆分到了 `/conf/xx.js` 中
 ![image.png](/legacy/13a2b97c3617197f.png)
-各类配置的参考路径： [https://github.com/tangly1024/NotionNext/tree/main/conf](https://github.com/tangly1024/NotionNext/tree/main/conf)
-主题支持的配置内容参考路径： [https://github.com/tangly1024/NotionNext/blob/main/themes/example/config.js](https://github.com/tangly1024/NotionNext/blob/main/themes/example/config.js)
+各类配置的参考路径： [https://github.com/notionnext-org/NotionNext/tree/main/conf](https://github.com/notionnext-org/NotionNext/tree/main/conf)
+主题支持的配置内容参考路径： [https://github.com/notionnext-org/NotionNext/blob/main/themes/example/config.js](https://github.com/notionnext-org/NotionNext/blob/main/themes/example/config.js)
 
 1. `NOTION_PAGE_ID` 必须在你的环境变量或代码中配置，不支持Notion_Config文档配置
 
@@ -88,7 +88,7 @@ NEXT_PUBLIC_WIDGET_PET_SWITCH_THEME=false
 1. 强烈建议添加的配置
 `**AUTHOR**`，作者名
 `**LINK**`，你的站点网址
-`**CONTACT_EMAIL **`, 你的联系邮箱，更多联系方式，在此查看配置方式： [https://github.com/tangly1024/NotionNext/blob/main/conf/contact.config.js](https://github.com/tangly1024/NotionNext/blob/main/conf/contact.config.js)
+`**CONTACT_EMAIL **`, 你的联系邮箱，更多联系方式，在此查看配置方式： [https://github.com/notionnext-org/NotionNext/blob/main/conf/contact.config.js](https://github.com/notionnext-org/NotionNext/blob/main/conf/contact.config.js)
 （务必配置你自己的联系方式！）
 
 
@@ -144,7 +144,7 @@ A new tool that blends your everyday work apps into one. It's the all-in-one wor
 ## 2. 修改代码
 
 ::: tip 提示
-重要：站点的大部分配置都可以在您代码仓库的 **[blog.config.js](https://github.com/tangly1024/NotionNext/blob/main/blog.config.js)**** **文件中找到；
+重要：站点的大部分配置都可以在您代码仓库的 **[blog.config.js](https://github.com/notionnext-org/NotionNext/blob/main/blog.config.js)**** **文件中找到；
 您只需修改对应的配置，Vercel将自动部署您Github仓库中的最新代码。
 :::
 
@@ -214,7 +214,7 @@ LINK: process.env.NEXT_PUBLIC_LINK || 'https://qq.com', // 修改后
 
 #### 内置主题名称一览（与仓库同步）
 
-`NEXT_PUBLIC_THEME` / `THEME` 的取值需与仓库 `[themes/](https://github.com/tangly1024/NotionNext/tree/main/themes)` 下的**文件夹名**一致（`next.config.js` 会在构建时扫描该目录）。以当前 **main** 分支为例，内置主题包括：**claude**、**commerce**、**example**、**fukasawa**、**fuwari**、**game**、**gitbook**、**heo**、**hexo**、**landing**、**magzine**、**matery**、**medium**、**movie**、**nav**、**next**、**nobelium**、**opc**、**photo**、**plog**、**proxio**、**simple**、**starter**、**typography**。
+`NEXT_PUBLIC_THEME` / `THEME` 的取值需与仓库 `[themes/](https://github.com/notionnext-org/NotionNext/tree/main/themes)` 下的**文件夹名**一致（`next.config.js` 会在构建时扫描该目录）。以当前 **main** 分支为例，内置主题包括：**claude**、**commerce**、**example**、**fukasawa**、**fuwari**、**game**、**gitbook**、**heo**、**hexo**、**landing**、**magzine**、**matery**、**medium**、**movie**、**nav**、**next**、**nobelium**、**opc**、**photo**、**plog**、**proxio**、**simple**、**starter**、**typography**。
 
 - **默认**一般为 **simple**；与 `blog.config.js` 中 `THEME` 的写法保持一致即可。
 
@@ -251,7 +251,7 @@ LINK: process.env.NEXT_PUBLIC_LINK || '/user-guide/intro', // 站点域名
 #### 修改示例
 
 ### 如何知道key？
-在[blog.config.js](https://github.com/tangly1024/NotionNext/blob/main/blog.config.js)文件中可以看到大量的配置项，配置项中的类似 `process.env.``**NEXT_PUBLIC_THEME**`** **； 这样的结构中、加粗部分就是key的名字。例如以下配置表明当前仓库默认值主题为 **simple**（也可通过环境变量改为 hexo 等）。
+在[blog.config.js](https://github.com/notionnext-org/NotionNext/blob/main/blog.config.js)文件中可以看到大量的配置项，配置项中的类似 `process.env.``**NEXT_PUBLIC_THEME**`** **； 这样的结构中、加粗部分就是key的名字。例如以下配置表明当前仓库默认值主题为 **simple**（也可通过环境变量改为 hexo 等）。
 ```JavaScript
 THEME: process.env.NEXT_PUBLIC_THEME || 'simple', // 默认主题
 ```

--- a/docs/user-guide/config/algolia.md
+++ b/docs/user-guide/config/algolia.md
@@ -42,7 +42,7 @@ Algolia是一家提供全文搜索和实时搜索解决方案的云服务提供�
 ~~所有主题已支持Algolia
 :::
 
-只需在部署平台的环境变量中添加以下四项配置即可开启，相关配置可参考仓库 [conf/plugin.config.js](https://github.com/tangly1024/NotionNext/blob/main/conf/plugin.config.js)。
+只需在部署平台的环境变量中添加以下四项配置即可开启，相关配置可参考仓库 [conf/plugin.config.js](https://github.com/notionnext-org/NotionNext/blob/main/conf/plugin.config.js)。
 
 在algolia后台可以查询到 apikey相关参数，[https://dashboard.algolia.com/account/api-keys/](https://dashboard.algolia.com/account/api-keys/)
 

--- a/docs/user-guide/config/notion-next-api_base_url.md
+++ b/docs/user-guide/config/notion-next-api_base_url.md
@@ -8,7 +8,7 @@
 这是一个临时的配置，用于解决4.9.0→4.9.1版本由于notion接口变化产生站点无法编译的异常。并非每一个人都遇到，若你的站点能够正常部署，并且没有出现530异常，则可以忽略此文。
 :::
 
-相关提交与说明可参考：[https://github.com/tangly1024/NotionNext/pull/3632](https://github.com/tangly1024/NotionNext/pull/3632)
+相关提交与说明可参考：[https://github.com/notionnext-org/NotionNext/pull/3632](https://github.com/notionnext-org/NotionNext/pull/3632)
 
 
 ## 配置的作用

--- a/docs/user-guide/config/notion-next-custom-properties.md
+++ b/docs/user-guide/config/notion-next-custom-properties.md
@@ -43,7 +43,7 @@ type，status，title，summary，slug，category，date，tags，icon，passwor
 
 ### 前提是
 
-你要在NotionNext的 [blog.config.js](https://github.com/tangly1024/NotionNext/blob/main/blog.config.js#L133-L144) 代码中做一些小小的配置：找到[以下代码](https://github.com/tangly1024/NotionNext/blob/abc4a32409c9efb7a9fe527eea37c3fdba69a453/blog.config.js#L126-L135)，代码左侧是系统的默认字段名，右边则是你的Notion数据库中对应的字段名。修改代码后，你的站点就会重新生效，按照中文表头读取Notion数据库。
+你要在NotionNext的 [blog.config.js](https://github.com/notionnext-org/NotionNext/blob/main/blog.config.js#L133-L144) 代码中做一些小小的配置：找到[以下代码](https://github.com/notionnext-org/NotionNext/blob/abc4a32409c9efb7a9fe527eea37c3fdba69a453/blog.config.js#L126-L135)，代码左侧是系统的默认字段名，右边则是你的Notion数据库中对应的字段名。修改代码后，你的站点就会重新生效，按照中文表头读取Notion数据库。
 
 ![Untitled](/legacy/8a095c2234a52d84.png)
 
@@ -68,7 +68,7 @@ NEXT_PUBLIC_NOTION_PROPERTY_ICON=图标
 
 ## 结语
 
-感谢网友们对此项目的贡献，有遇到问题，或者新想法欢迎[提交issue](https://github.com/tangly1024/NotionNext/issues/new/choose)。
+感谢网友们对此项目的贡献，有遇到问题，或者新想法欢迎[提交issue](https://github.com/notionnext-org/NotionNext/issues/new/choose)。
 
 ## 原文链接
 

--- a/docs/user-guide/config/site-basics.md
+++ b/docs/user-guide/config/site-basics.md
@@ -22,7 +22,7 @@
 
 ### 1. 站点信息
 
-网站的社交地址，站点域名，作者信息，以及默认主题在站点的配置文件 [blog.config.js ](https://github.com/tangly1024/NotionNext/blob/fd29df3b26211aad04a9e6462cae038d7006e826/blog.config.js#L20-L34)中可以找到，您可以在配置文件中修改配置。
+网站的社交地址，站点域名，作者信息，以及默认主题在站点的配置文件 [blog.config.js ](https://github.com/notionnext-org/NotionNext/blob/fd29df3b26211aad04a9e6462cae038d7006e826/blog.config.js#L20-L34)中可以找到，您可以在配置文件中修改配置。
 
 ```JavaScript
 AUTHOR: process.env.NEXT_PUBLIC_AUTHOR || 'NotionNext', // 您的昵称 例如 tangly1024
@@ -69,7 +69,7 @@ LINK: process.env.NEXT_PUBLIC_LINK || '/user-guide/intro', // 网站地址
 
 #### 自定义社交图标按钮
 
-hexo主题的图标按钮在[此处修改](https://github.com/tangly1024/NotionNext/blob/main/themes/hexo/components/SocialButton.js),
+hexo主题的图标按钮在[此处修改](https://github.com/notionnext-org/NotionNext/blob/main/themes/hexo/components/SocialButton.js),
 
 例如github的图标是： `fab fa-github` ，可访问[fontawesome获取](https://fontawesome.com/search?o=r&m=free)其他图标
 
@@ -162,7 +162,7 @@ favicon在线制作,icon制作,网站图标,网站图标制作,ico图标制作
 您可以自行决定站点的样式和执行的脚本，NotionNext支持两种方式引入您的css 和 js ：
 
 - 方法一：外部文件引入
-[blog.config.js](https://github.com/tangly1024/NotionNext/blob/main/blog.config.js#L34-L35) 中 配置:`CUSTOM_EXTERNAL_JS `和`CUSTOM_EXTERNAL_CSS `即可
+[blog.config.js](https://github.com/notionnext-org/NotionNext/blob/main/blog.config.js#L34-L35) 中 配置:`CUSTOM_EXTERNAL_JS `和`CUSTOM_EXTERNAL_CSS `即可
 ```Bash
 // 自定义外部脚本，外部样式
 CUSTOM_EXTERNAL_JS: [''], // e.g. ['http://xx.com/script.js','http://xx.com/script.js']
@@ -170,8 +170,8 @@ CUSTOM_EXTERNAL_CSS: [''], // e.g. ['http://xx.com/style.css','http://xx.com/sty
 ```
 
 - 方法二：内部自定义
-  - [/public/css/custom.css](https://github.com/tangly1024/NotionNext/blob/main/public/css/custom.css) 文件可以直接自定义样式。
-  - [/public/js/custom.js](https://github.com/tangly1024/NotionNext/blob/main/public/js/custom.js) 文件中编写脚本将被自动引入页面。
+  - [/public/css/custom.css](https://github.com/notionnext-org/NotionNext/blob/main/public/css/custom.css) 文件可以直接自定义样式。
+  - [/public/js/custom.js](https://github.com/notionnext-org/NotionNext/blob/main/public/js/custom.js) 文件中编写脚本将被自动引入页面。
   - 每个主题的自定义css文件，例如 /public/css/theme-hexo.css
 
 ::: info 问题
@@ -366,7 +366,7 @@ STARRY_SKY: process.env.NEXT_PUBLIC_STARRY_SKY || false, // 开关
 
 您共享的Notion页，他人只有查看权限，除非你手动开启编辑和评论的权限。
 
-另外，若您不希望别人访问到你的源Notion页面，可选择关闭Noton页面共享，然后通过Notion的[access_token](https://github.com/tangly1024/NotionNext/issues/116#issuecomment-1081260413)进行数据访问。
+另外，若您不希望别人访问到你的源Notion页面，可选择关闭Noton页面共享，然后通过Notion的[access_token](https://github.com/notionnext-org/NotionNext/issues/116#issuecomment-1081260413)进行数据访问。
 
 ![Untitled](/legacy/e39a99d8b73be154.png)
 

--- a/docs/user-guide/deploy/vps.md
+++ b/docs/user-guide/deploy/vps.md
@@ -143,7 +143,7 @@ Complete!
 cd ~
 
 # 将Git上的代码下载到服务器中 ;
-git clone https://github.com/tangly1024/NotionNext &&
+git clone https://github.com/notionnext-org/NotionNext &&
 
 # 若您的服务器因为网络问题，无法访问github，可手动下载NotionNext代码 上传至服务器
 ```
@@ -676,14 +676,14 @@ nohup yarn start &gt;/dev/null 2&gt;&1 &
 删除环境变量可用以下命令： `unset NOTION_PAGE_ID`
 :::
 
-- 支持环境变量的配置可参考[blog.config.js](https://github.com/tangly1024/NotionNext/blob/main/blog.config.js) 文件
+- 支持环境变量的配置可参考[blog.config.js](https://github.com/notionnext-org/NotionNext/blob/main/blog.config.js) 文件
 
 
 ### 2.修改代码
 
 - 如果修改blog.config.js或其他代码文件，NodeJS环境需要重新执行 `yarn build` 才可 生效，Docker环境重新执行前面的docker build 相关命令即可重新构建镜像。
 
-- 您可以在项目根目录的[`.env.local`](https://github.com/tangly1024/NotionNext/blob/main/.env.local)文件中配置您的环境变量
+- 您可以在项目根目录的[`.env.local`](https://github.com/notionnext-org/NotionNext/blob/main/.env.local)文件中配置您的环境变量
 
 - 重新编译后需要先关闭旧进程，再用 `yarn start` 重启服务 。
 
@@ -753,7 +753,7 @@ sudo systemctl reload nginx
 cd NotionNext
 
 # 从仓库更新拉取最新代码
-git pull https://github.com/tangly1024/NotionNext
+git pull https://github.com/notionnext-org/NotionNext
 
 # 编译新版代码
 yarn build

--- a/docs/user-guide/development/about-tailwindcss.md
+++ b/docs/user-guide/development/about-tailwindcss.md
@@ -185,7 +185,7 @@ Customizing the default color palette for your project.
 
 ### 以example 主题为例：
 
-如何修改example主题的背景色？在/themes/example/index.js 中 ,找到[ theme-example的这行](https://github.com/tangly1024/NotionNext/blob/e6c69dbbaecb1419f0ca3fa0a15b44cf24be0df0/themes/example/index.js#L65)：
+如何修改example主题的背景色？在/themes/example/index.js 中 ,找到[ theme-example的这行](https://github.com/notionnext-org/NotionNext/blob/e6c69dbbaecb1419f0ca3fa0a15b44cf24be0df0/themes/example/index.js#L65)：
 
 ```JavaScript
 &lt;div id='theme-example' className={`${siteConfig('FONT_STYLE')} dark:text-gray-300  bg-white dark:bg-black scroll-smooth`} &gt;

--- a/docs/user-guide/development/getting-started.md
+++ b/docs/user-guide/development/getting-started.md
@@ -43,7 +43,7 @@ NotionNext操作手册中，有关于自定义脚本和样式的引入方式；�
 
 ## 自行开发
 
-如果上述的配置方式，不能满足您的需要，例如新增组件、深度定制等等。您可以选择在github上[发起issue](https://github.com/tangly1024/NotionNext/issues/new/choose)，提出改进页面的建议，或者遵循此教程，进行您的开发之旅。
+如果上述的配置方式，不能满足您的需要，例如新增组件、深度定制等等。您可以选择在github上[发起issue](https://github.com/notionnext-org/NotionNext/issues/new/choose)，提出改进页面的建议，或者遵循此教程，进行您的开发之旅。
 
 ::: tip 提示
 可选Codespaces云开发，以及本地开发两种方案。

--- a/docs/user-guide/development/notion-next-develop-with-ai.md
+++ b/docs/user-guide/development/notion-next-develop-with-ai.md
@@ -74,7 +74,7 @@ Firebase会自动导入项目代码并进行环境安装。
 
 不建议直接修改原先的主题，否则后续如果我也同步修改了这个主题文件夹，在更新的过程可能会产生大量的冲突。
 
-在themes 目录，找到你较喜欢的主题，或者和你预期的新主题结构比较类似的主题，例如example主题文件夹。各主题的补充说明见仓库 [docs/themes](https://github.com/tangly1024/NotionNext/tree/main/docs/themes)（如 Fuwari、Claude 等）。点击右键copy复制这个文件夹。
+在themes 目录，找到你较喜欢的主题，或者和你预期的新主题结构比较类似的主题，例如example主题文件夹。各主题的补充说明见仓库 [docs/themes](https://github.com/notionnext-org/NotionNext/tree/main/docs/themes)（如 Fuwari、Claude 等）。点击右键copy复制这个文件夹。
 
 ![image.png](/legacy/0a4be92d0f2060f3.png)
 

--- a/docs/user-guide/development/notionnext-how-to-pr.md
+++ b/docs/user-guide/development/notionnext-how-to-pr.md
@@ -11,22 +11,22 @@
 
 ### 1.****创建新主题****
 
-如果您想创建一个新主题、并提交到NotionNext，请复制一个[`/themes/example`](https://github.com/tangly1024/NotionNext/blob/main/themes/example)文件夹在[`themes`](https://github.com/tangly1024/NotionNext/blob/main/themes)目录下，并修改文件夹的名称主题的名称。
+如果您想创建一个新主题、并提交到NotionNext，请复制一个[`/themes/example`](https://github.com/notionnext-org/NotionNext/blob/main/themes/example)文件夹在[`themes`](https://github.com/notionnext-org/NotionNext/blob/main/themes)目录下，并修改文件夹的名称主题的名称。
 
 
 ### 2.**添加本地化**
 
 如果您的语言尚未得到NotionNext的支持，欢迎贡献本地化！按照以下步骤添加新的本地化：
-1. 在[/lib/lang](https://github.com/tangly1024/NotionNext/blob/main/lib/lang)中复制一个[en-US.js](https://github.com/tangly1024/NotionNext/blob/main/lib/lang/en-US.js)文件，并将文件命名为语言的代码（例如`zh-CN.js`）。
+1. 在[/lib/lang](https://github.com/notionnext-org/NotionNext/blob/main/lib/lang)中复制一个[en-US.js](https://github.com/notionnext-org/NotionNext/blob/main/lib/lang/en-US.js)文件，并将文件命名为语言的代码（例如`zh-CN.js`）。
 2. 开始翻译字符串。
-3. 将您的语言配置添加到[lang.js](https://github.com/tangly1024/NotionNext/blob/main/lib/lang.js)中。
+3. 将您的语言配置添加到[lang.js](https://github.com/notionnext-org/NotionNext/blob/main/lib/lang.js)中。
 
 欢迎将你的代码分支，合并到NotionNext主仓库中，要为NotionNext做出贡献，请按照以下步骤操作：
 
 
 ### 3.提交代码到NotionNext
 
-1. 将存储库[fork](https://github.com/tangly1024/NotionNext/fork)到您的GitHub帐户。
+1. 将存储库[fork](https://github.com/notionnext-org/NotionNext/fork)到您的GitHub帐户。
 
 1. 将存储库clone到您的设备上（或使用Codespaces之类的东西）。
 
@@ -37,7 +37,7 @@
 1. 提交修改并推送分支。(请勿在分支中提交您自己的配置信息)
 ![Untitled](/legacy/ead1ee047149aec5.png)
 
-1. 从fork中的分支[创建](https://github.com/tangly1024/NotionNext/compare)到NotionNext的`main`分支的[PR](https://github.com/tangly1024/NotionNext/compare)。
+1. 从fork中的分支[创建](https://github.com/notionnext-org/NotionNext/compare)到NotionNext的`main`分支的[PR](https://github.com/notionnext-org/NotionNext/compare)。
 
 ### 4. 提交 PR 前检查用户文档
 

--- a/docs/user-guide/help/community-rules.md
+++ b/docs/user-guide/help/community-rules.md
@@ -76,7 +76,7 @@ NotionNext提供了博客文档，社群交流，评论留言、邮件等渠道�
 
 我希望切换站点的主题为`example`，因此我在 GitHub 上修改了配置文件 `blog.config.js` 的`THEME`这个参数的配置，但在网页上并没有看到生效，我使用的部署方案是 Vercel 。以下是相关信息，请帮我看一下，非常感谢！
 
-1. 【代码地址】 [https://github.com/notionnext-org/NotionNext](https://github.com/notionnext-org/NotionNext) （这里贴你自己的仓库）
+1. 【代码地址】 `https://github.com/username/NotionNext` （这里贴你自己的仓库）
 
 1. 【NotionID】02ab3b8678004aa69e9e415905ef32a5 (这里可以贴你的页面ID)
 

--- a/docs/user-guide/help/community-rules.md
+++ b/docs/user-guide/help/community-rules.md
@@ -76,7 +76,7 @@ NotionNext提供了博客文档，社群交流，评论留言、邮件等渠道�
 
 我希望切换站点的主题为`example`，因此我在 GitHub 上修改了配置文件 `blog.config.js` 的`THEME`这个参数的配置，但在网页上并没有看到生效，我使用的部署方案是 Vercel 。以下是相关信息，请帮我看一下，非常感谢！
 
-1. 【代码地址】 [https://github.com/tangly1024/NotionNext](https://github.com/tangly1024/NotionNext) （这里贴你自己的仓库）
+1. 【代码地址】 [https://github.com/notionnext-org/NotionNext](https://github.com/notionnext-org/NotionNext) （这里贴你自己的仓库）
 
 1. 【NotionID】02ab3b8678004aa69e9e415905ef32a5 (这里可以贴你的页面ID)
 

--- a/docs/user-guide/help/community.md
+++ b/docs/user-guide/help/community.md
@@ -33,7 +33,7 @@
 为维护良好的交流环境，微信群需要您支付**￥29.9**的入群费（请小助理喝一杯咖啡）。
 :::
 
-对NotionNext代码做出[贡献](https://github.com/tangly1024/NotionNext/graphs/contributors)，或对《NotionNext帮助手册》有特别贡献的成员，可以免费入群。
+对NotionNext代码做出[贡献](https://github.com/notionnext-org/NotionNext/graphs/contributors)，或对《NotionNext帮助手册》有特别贡献的成员，可以免费入群。
 请添加小助理微信，并在申请原因中备注：`**付费入群-您的称呼**`** ， **助理会给您发一个收款码，支付成功后，助理会拉您进群❤
 ![image.png](/legacy/ada2c3f35445f279.png)
 #### 助理微信 （点击展开）
@@ -65,7 +65,7 @@
 - 我们只有**站长社群**，没有另外建立开发者社群，**开发者们通常在issue中进行留言沟通**。站长社群需要付费加入，但对于NotionNext的开发者们可免费入群。
 
 - 您可以通过以下方式成为开发者：
-  - 您需要自行通过**issue讨论区**或其它方式，定位到需要改动的代码，并且提交一个**解决问题的PR**，PR成功通过合并后即可成为[NotionNext的开发者](https://github.com/tangly1024/NotionNext/graphs/contributors)。
+  - 您需要自行通过**issue讨论区**或其它方式，定位到需要改动的代码，并且提交一个**解决问题的PR**，PR成功通过合并后即可成为[NotionNext的开发者](https://github.com/notionnext-org/NotionNext/graphs/contributors)。
 
 - 开发者们请联系小助理加群或与我对接。
 

--- a/docs/user-guide/help/feedback.md
+++ b/docs/user-guide/help/feedback.md
@@ -23,7 +23,7 @@
 
 ## Github开发者社区
 
-软件BUG和新需求，请在Github发布公开 [Issue](https://github.com/tangly1024/NotionNext/issues) 进行反馈；
+软件BUG和新需求，请在Github发布公开 [Issue](https://github.com/notionnext-org/NotionNext/issues) 进行反馈；
 
 - Issue请**严格按照模板填写**，否则**将被直接关闭**。
 
@@ -31,9 +31,9 @@
 
 > **https://s3-us-west-2.amazonaws.com/secure.notion-static.com/2c6cb87d-0e8f-451f-b40b-913fbe8165e6/%E4%B8%8B%E8%BD%BD_(1).png** Github
 >
-  - [反馈 BUG](https://github.com/tangly1024/NotionNext/issues/new?assignees=tangly1024&labels=bug&projects=&template=bug_report.md&title=)
->   - [新功能建议](https://github.com/tangly1024/NotionNext/issues/new?assignees=tangly1024&labels=enhancement&projects=&template=feature_request.md&title=)
->   - [Discussions](https://github.com/tangly1024/NotionNext/discussions) 开帖讨论
+  - [反馈 BUG](https://github.com/notionnext-org/NotionNext/issues/new?assignees=tangly1024&labels=bug&projects=&template=bug_report.md&title=)
+>   - [新功能建议](https://github.com/notionnext-org/NotionNext/issues/new?assignees=tangly1024&labels=enhancement&projects=&template=feature_request.md&title=)
+>   - [Discussions](https://github.com/notionnext-org/NotionNext/discussions) 开帖讨论
 
 
 ## 本站评论区

--- a/docs/user-guide/help/support-notion-next.md
+++ b/docs/user-guide/help/support-notion-next.md
@@ -22,13 +22,13 @@ NotionNext完全开源免费，欢迎您赞助或贡献代码，支持此项目�
 
 关于任务的认领，参考此Discussions
 
-[想参与 5.0 版本的开发吗？来报名吧！😎 · tangly1024 NotionNext · Discussion #2140](https://github.com/tangly1024/NotionNext/discussions/2140)
+[想参与 5.0 版本的开发吗？来报名吧！😎 · tangly1024 NotionNext · Discussion #2140](https://github.com/notionnext-org/NotionNext/discussions/2140)
 
 大家好，近期我们发布了4.3 版本，你可以在这里找到发布信息：NotionNext-Release 🎉 但 版本还有很多待完善的功能，我们非常期待能与社区的伙伴们一起共同构建 NotionNext 的生态，与社区一起发布最终的版本。为此，我们希望能够吸引更多对此感兴趣的同学们加入到 NotionNext 新版本的开发中来🥳。 如果你对参与这些任务感兴趣，可以在讨论区看到内容，待修复的bug ...
 
 关于项目的计划，参考此RoadMap：
 
-[Roadmap](https://github.com/tangly1024/NotionNext/wiki/Roadmap)
+[Roadmap](https://github.com/notionnext-org/NotionNext/wiki/Roadmap)
 
 使用 NextJS + Notion API 实现的，支持多种部署方案的静态博客，无需服务器、零门槛搭建网站，为Notion和所有创作者设计。 (A static blog built with NextJS and Notion API, supporting multiple deployment options. No server required, zero threshold t...
 

--- a/docs/user-guide/menu-secondary.md
+++ b/docs/user-guide/menu-secondary.md
@@ -102,7 +102,7 @@ Menu,SubMenu 这两个类型本质只是菜单，唯一功能是跳转到slug指
 
 ::: tip 提示
 **特别提醒：**
-在V3.13版本中 ，不要在您的数据库中添加多个视图，这将会导致您的菜单乱序。如需添加视图以便分类整理文章，建议另外新建一个视图单页，参考下文： [https://github.com/tangly1024/NotionNext/issues/1056](https://github.com/tangly1024/NotionNext/issues/1056)
+在V3.13版本中 ，不要在您的数据库中添加多个视图，这将会导致您的菜单乱序。如需添加视图以便分类整理文章，建议另外新建一个视图单页，参考下文： [https://github.com/notionnext-org/NotionNext/issues/1056](https://github.com/notionnext-org/NotionNext/issues/1056)
 :::
 
 在V4.0之后的新版本可以忽略此问题。

--- a/docs/user-guide/notion/how-to-add-link-for-text-in-notion.md
+++ b/docs/user-guide/notion/how-to-add-link-for-text-in-notion.md
@@ -19,7 +19,7 @@ Notion支持在文本上添加链接，从而实现点击文字跳转到任意�
 ## Notion内链
 
 ::: tip 提示
-在 [v4.5.2](https://github.com/tangly1024/NotionNext/releases/tag/v4.5.2) 之前的版本中，添加博客文章的内链，需要在网页中打开你的博客并复制完整url，再粘贴到你的notion中。
+在 [v4.5.2](https://github.com/notionnext-org/NotionNext/releases/tag/v4.5.2) 之前的版本中，添加博客文章的内链，需要在网页中打开你的博客并复制完整url，再粘贴到你的notion中。
 :::
 
 例如：浏览器中复制 [https://blog.tangly1024.com/article/the-ai-era](https://blog.tangly1024.com/article/the-ai-era) ，然后将URL粘贴在Notion的文字上，从而实现文字点击跳转 →《[文字链接](https://blog.tangly1024.com/article/the-ai-era)》 。

--- a/docs/user-guide/operations/wechat-offical-account.md
+++ b/docs/user-guide/operations/wechat-offical-account.md
@@ -7,7 +7,7 @@
 ::: warning 注意
 ~~OpenWrite停止此项服务，公众号引流的方案失效了，因此以下文章内容已过期。~~
 新版本引入 TechGrow方案进行验证码解锁：
-感謝[大佬](https://github.com/yunhe-dev)的[https://yunhe.dev/](https://yunhe.dev/)提交：[https://github.com/tangly1024/NotionNext/pull/3826](https://github.com/tangly1024/NotionNext/pull/3826)
+感謝[大佬](https://github.com/yunhe-dev)的[https://yunhe.dev/](https://yunhe.dev/)提交：[https://github.com/notionnext-org/NotionNext/pull/3826](https://github.com/notionnext-org/NotionNext/pull/3826)
 使用体验和OpenWrite一致，页面显示查看更多按钮，用户点击后需要关注公众号查看内容：
 ![05059467ede12063fcbfb0d7bb619f58.png](/legacy/1babe0067f81a105.png)
 ![image.png](/legacy/17f98076ad7a917b.png)

--- a/docs/user-guide/plugins/notion-next-chat-base.md
+++ b/docs/user-guide/plugins/notion-next-chat-base.md
@@ -23,7 +23,7 @@ Chatbase.co 是**一款为网站构建自定义ChatGPT 界面的工具**，用�
 
 ## 配置方法
 
-用环境变量或修改代码的方式，在[blog.config.js](https://github.com/tangly1024/NotionNext/blob/48cb3ee6779c117bcb6b61e5cb89fbd1c541a115/blog.config.js#L156)中添加您的chatbase-id即可。
+用环境变量或修改代码的方式，在[blog.config.js](https://github.com/notionnext-org/NotionNext/blob/48cb3ee6779c117bcb6b61e5cb89fbd1c541a115/blog.config.js#L156)中添加您的chatbase-id即可。
 
 ```YAML
 //   ********挂件组件相关********

--- a/docs/user-guide/plugins/notion-next-facebook-chat-plugn.md
+++ b/docs/user-guide/plugins/notion-next-facebook-chat-plugn.md
@@ -43,7 +43,7 @@ FaceBook 官方提供的聊天插件，可以方便您与访客实时聊天。
 
 ## 配置方式
 
-在NotionNext后台添加两个环境变量即可开启FBChat插件 ， 对应配置文件路径 [blog.config.js](https://github.com/tangly1024/NotionNext/blob/70cc96d8f16e71abc8a21e777c4b984680ab5a4b/blog.config.js#L99-L100) 。
+在NotionNext后台添加两个环境变量即可开启FBChat插件 ， 对应配置文件路径 [blog.config.js](https://github.com/notionnext-org/NotionNext/blob/70cc96d8f16e71abc8a21e777c4b984680ab5a4b/blog.config.js#L99-L100) 。
 
 这两个参数如何获得，请阅读下方的注册方法部分。
 
@@ -130,7 +130,7 @@ facebook上创建一个公共主页很简单，按照步骤创建好主页后，
 
 至此，你已经获取到了`APP_ID`和`PAGE_ID`。
 
-在NotionNext后台添加两个环境变量即可开启FBChat插件 ， 对应配置文件路径 [blog.config.js](https://github.com/tangly1024/NotionNext/blob/70cc96d8f16e71abc8a21e777c4b984680ab5a4b/blog.config.js#L99-L100) 。
+在NotionNext后台添加两个环境变量即可开启FBChat插件 ， 对应配置文件路径 [blog.config.js](https://github.com/notionnext-org/NotionNext/blob/70cc96d8f16e71abc8a21e777c4b984680ab5a4b/blog.config.js#L99-L100) 。
 
 
 ## 关于Facebook后台设置

--- a/docs/user-guide/plugins/notion-next-google-adsense.md
+++ b/docs/user-guide/plugins/notion-next-google-adsense.md
@@ -21,13 +21,13 @@
 
 ## 配置方式
 
-1. 获取谷歌账号的 PUB_ID 填写到[站点配置](https://github.com/tangly1024/NotionNext/blob/9197b3c6bbcefc02e253b6c13b8c0abdc9cdb84f/blog.config.js#L331)
+1. 获取谷歌账号的 PUB_ID 填写到[站点配置](https://github.com/notionnext-org/NotionNext/blob/9197b3c6bbcefc02e253b6c13b8c0abdc9cdb84f/blog.config.js#L331)
 ![Untitled](/legacy/24c727d62c3c04c5.png)
 
 1. 在谷歌后台创建四种类型的广告单元，获取广告单元的ID
 ![Untitled](/legacy/450a125a54560154.png)
 
-1. 在[代码中配置](https://github.com/tangly1024/NotionNext/blob/9197b3c6bbcefc02e253b6c13b8c0abdc9cdb84f/blog.config.js#L333-L336)广告单元ID
+1. 在[代码中配置](https://github.com/notionnext-org/NotionNext/blob/9197b3c6bbcefc02e253b6c13b8c0abdc9cdb84f/blog.config.js#L333-L336)广告单元ID
 ![Untitled](/legacy/1cada855df1a7c22.png)
 
 
@@ -35,10 +35,10 @@
 
 需要改动代码，而且不能嵌入到文章的指定段落。
 
-1. 在你需要引入特定自定义广告的地方添加组件代码 &lt;AdSlot /&gt; 即可 相关[AdSlot源码](https://github.com/tangly1024/NotionNext/blob/9197b3c6bbcefc02e253b6c13b8c0abdc9cdb84f/components/GoogleAdsense.js#L51-L95)
+1. 在你需要引入特定自定义广告的地方添加组件代码 &lt;AdSlot /&gt; 即可 相关[AdSlot源码](https://github.com/notionnext-org/NotionNext/blob/9197b3c6bbcefc02e253b6c13b8c0abdc9cdb84f/components/GoogleAdsense.js#L51-L95)
 ![Untitled](/legacy/2243297ab514eb6b.png)
 
-1. 相关使用案例 , [Simple主题首页](https://github.com/tangly1024/NotionNext/blob/9197b3c6bbcefc02e253b6c13b8c0abdc9cdb84f/themes/simple/index.js#L74)加入了一个原生广告单元
+1. 相关使用案例 , [Simple主题首页](https://github.com/notionnext-org/NotionNext/blob/9197b3c6bbcefc02e253b6c13b8c0abdc9cdb84f/themes/simple/index.js#L74)加入了一个原生广告单元
 ![Untitled](/legacy/555bcf37a684b39e.png)
 
 

--- a/docs/user-guide/plugins/notion-next-plugin-live2d.md
+++ b/docs/user-guide/plugins/notion-next-plugin-live2d.md
@@ -17,7 +17,7 @@
 
 目前所有主题都支持宠物挂件。
 
-开启方式，源文件在[blog.config.js](https://github.com/tangly1024/NotionNext/blob/8103e23aac7219789c77e412a1bc24dd2a2683b5/blog.config.js#L152C2-L158C1)中，默认是开状态
+开启方式，源文件在[blog.config.js](https://github.com/notionnext-org/NotionNext/blob/8103e23aac7219789c77e412a1bc24dd2a2683b5/blog.config.js#L152C2-L158C1)中，默认是开状态
 
 ```JavaScript
 // 悬浮挂件
@@ -36,7 +36,7 @@
 `WIDGET_PET_LINK` 这个参数制定的是动画模型的加载地址，目前默认使用的是茶杯狗。
 
 ::: tip 提示
-由于每个动画模型的高度不同，可能需要您在[代码中](https://github.com/tangly1024/NotionNext/blob/8103e23aac7219789c77e412a1bc24dd2a2683b5/components/Live2D.js#L38)修改模型的高度height，否则会很怪异。
+由于每个动画模型的高度不同，可能需要您在[代码中](https://github.com/notionnext-org/NotionNext/blob/8103e23aac7219789c77e412a1bc24dd2a2683b5/components/Live2D.js#L38)修改模型的高度height，否则会很怪异。
 
 ```HTML
 &lt;canvas id="live2d" className='cursor-pointer' width="280" **height="250"** onClick={handleClick} alt='切换主题' title='切换主题' /&gt;

--- a/docs/user-guide/themes/heo.md
+++ b/docs/user-guide/themes/heo.md
@@ -25,7 +25,7 @@
 
 将代码版本更新到4.0以后
 
-将您的默认主题设置为HEO，相关的所有配置都可以在[ /themes/heo/config.js ](https://github.com/tangly1024/NotionNext/blob/main/themes/heo/config.js)文件中找到。接下来我会介绍这个主题的功能区。
+将您的默认主题设置为HEO，相关的所有配置都可以在[ /themes/heo/config.js ](https://github.com/notionnext-org/NotionNext/blob/main/themes/heo/config.js)文件中找到。接下来我会介绍这个主题的功能区。
 
 ![Untitled](/legacy/c18a66ba4b1525db.png)
 
@@ -82,7 +82,7 @@ HEO_COLOR_ACCENT: '#f59e0b'
 
 ### 英雄区左侧
 
-1. **左上角的卡牌**点击是随机跳转到一篇文章，此功能无法修改配置，但是可以在源代码[themes/heo/components/Hero.js](https://github.com/tangly1024/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/components/Hero.js#L58)中看到。
+1. **左上角的卡牌**点击是随机跳转到一篇文章，此功能无法修改配置，但是可以在源代码[themes/heo/components/Hero.js](https://github.com/notionnext-org/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/components/Hero.js#L58)中看到。
 ```JavaScript
 // 跳转到任意文章
   function handleClickBanner() {
@@ -92,7 +92,7 @@ HEO_COLOR_ACCENT: '#f59e0b'
   }
 ```
 
-1. **左上卡牌大标题** [themes/heo/config.js](https://github.com/tangly1024/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/config.js#L12C1-L15C34)
+1. **左上卡牌大标题** [themes/heo/config.js](https://github.com/notionnext-org/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/config.js#L12C1-L15C34)
 ![Untitled](/legacy/9db05c53471e735b.png)
 ```JavaScript
 // 英雄区(首页顶部大卡)
@@ -101,7 +101,7 @@ HERO_TITLE_2: '与思维认知',
 HERO_TITLE_3: 'TANGLY1024.COM',
 ```
 
-1. **左上角卡牌背景滚动图**，会循环展示一些技能的图标，可以在 [themes/heo/config.js](https://github.com/tangly1024/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/config.js#L38)中配置
+1. **左上角卡牌背景滚动图**，会循环展示一些技能的图标，可以在 [themes/heo/config.js](https://github.com/notionnext-org/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/config.js#L38)中配置
 <details>
 <summary>展开相关代码</summary>
 
@@ -170,7 +170,7 @@ HERO_TITLE_3: 'TANGLY1024.COM',
 </details>
 ![Untitled](/legacy/447da302a4673a35.png)
 
-1. **左下角三个导航标签**，点击跳到特定页面，可以在 [themes/heo/configs.js](https://github.com/tangly1024/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/config.js#L20-L23) 中配置
+1. **左下角三个导航标签**，点击跳到特定页面，可以在 [themes/heo/configs.js](https://github.com/notionnext-org/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/config.js#L20-L23) 中配置
 ![Untitled](/legacy/e35b224d4c228111.png)
 ```JavaScript
 // 英雄区显示三个置顶分类
@@ -185,7 +185,7 @@ HERO_CATEGORY_3: { title: '实用教程', url: '/tag/实用教程' },
 ![Untitled](/legacy/9907a9bffcfe3c0c.png)
 
 ### 英雄区右侧
-显示置顶文章的标题文字，以及跳转链接， 配置方式 [themes/heo/config.js](https://github.com/tangly1024/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/config.js#L16-L18)
+显示置顶文章的标题文字，以及跳转链接， 配置方式 [themes/heo/config.js](https://github.com/notionnext-org/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/config.js#L16-L18)
 ![Untitled](/legacy/965acb63a2b281e2.png)
 ```JavaScript
 HERO_TITLE_4: '新版上线',
@@ -211,7 +211,7 @@ HERO_RECOMMEND_POST_TAG: '推荐',
 ![Untitled](/legacy/ca196d12d53b0565.png)
 https://notion.so/signed/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F4ff9b53a-b204-4696-8d8c-b4c01bc05e50%2FUntitled.mp4?table=block&id=74bfbeea-9fb8-4208-9399-4b7034d14741
   1. 个人资料卡牌**欢迎语**
-此处的文字点击会发生变化，在 [themes/heo/config.js](https://github.com/tangly1024/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/config.js#L26-L34) 中配置
+此处的文字点击会发生变化，在 [themes/heo/config.js](https://github.com/notionnext-org/NotionNext/blob/b9f52f386c1a7110a15ba5bf005c8eccb190b1f3/themes/heo/config.js#L26-L34) 中配置
 ![Untitled](/legacy/9221764faff2cd6d.png)
 ```JavaScript
 INFOCARD_GREETINGS: [

--- a/docs/user-guide/themes/magzine.md
+++ b/docs/user-guide/themes/magzine.md
@@ -162,7 +162,7 @@ const CONFIG = {
     {
       name: '开发者',
       menus: [
-        { title: 'Github', href: 'https://github.com/tangly1024/NotionNext' },
+        { title: 'Github', href: 'https://github.com/notionnext-org/NotionNext' },
         { title: '关于作者', href: '/about' }
       ]
     },
@@ -213,7 +213,7 @@ export default CONFIG
     {
       name: '开发者',
       menus: [
-        { title: 'Github', href: 'https://github.com/tangly1024/NotionNext' },
+        { title: 'Github', href: 'https://github.com/notionnext-org/NotionNext' },
         { title: '关于作者', href: '/about' }
       ]
     },
@@ -270,7 +270,7 @@ export default CONFIG
         "menus": [
             {
                 "title": "Github",
-                "href": "https://github.com/tangly1024/NotionNext"
+                "href": "https://github.com/notionnext-org/NotionNext"
             },
             {
                 "title": "开发帮助",
@@ -278,11 +278,11 @@ export default CONFIG
             },
             {
                 "title": "功能反馈",
-                "href": "https://github.com/tangly1024/NotionNext/issues/new/choose"
+                "href": "https://github.com/notionnext-org/NotionNext/issues/new/choose"
             },
             {
                 "title": "技术讨论",
-                "href": "https://github.com/tangly1024/NotionNext/discussions"
+                "href": "https://github.com/notionnext-org/NotionNext/discussions"
             },
             {
                 "title": "关于作者",

--- a/docs/user-guide/themes/overview.md
+++ b/docs/user-guide/themes/overview.md
@@ -14,7 +14,7 @@ NotionNext会扫描/themes目录下的文件夹，并根据文件夹的名字生
 
 ## 主题预览
 
-内置主题以 GitHub 仓库 `[themes/](https://github.com/tangly1024/NotionNext/tree/main/themes)` 目录为准（会随版本迭代增减）。当前主线常见主题包括：`simple`（**新建仓库默认**，见 `blog.config.js` 的 `THEME`）、`next`、`medium`、`hexo`、`fukasawa`、`gitbook`、`matery`、`heo`、`nobelium`、`plog`、`landing`、`nav`、`starter`、`commerce`、`magzine`、`photo`、`movie`、`game`、`fuwari`、`claude`、`proxio`、`typography`、`example` 等。
+内置主题以 GitHub 仓库 `[themes/](https://github.com/notionnext-org/NotionNext/tree/main/themes)` 目录为准（会随版本迭代增减）。当前主线常见主题包括：`simple`（**新建仓库默认**，见 `blog.config.js` 的 `THEME`）、`next`、`medium`、`hexo`、`fukasawa`、`gitbook`、`matery`、`heo`、`nobelium`、`plog`、`landing`、`nav`、`starter`、`commerce`、`magzine`、`photo`、`movie`、`game`、`fuwari`、`claude`、`proxio`、`typography`、`example` 等。
 
 可按用途粗选：GitBook 偏文档；Nav 偏导航聚合；Landing / Starter 偏落地页；Plog、Photo 偏图集；更多说明见各主题子文档或源码中对应 `config.js`。
 
@@ -84,7 +84,7 @@ THEME: process.env.NEXT_PUBLIC_THEME || 'simple', // 与当前主仓库默认值
 
 ### 在线切换主题
 
-您可以像我的博客站一样，在页面上开启一个实时切换主题的按钮，以供预览；开启方式：在主仓库 `[conf/widget.config.js](https://github.com/tangly1024/NotionNext/blob/main/conf/widget.config.js)` 中调整（或在部署后台配置环境变量 `NEXT_PUBLIC_THEME_SWITCH`）：
+您可以像我的博客站一样，在页面上开启一个实时切换主题的按钮，以供预览；开启方式：在主仓库 `[conf/widget.config.js](https://github.com/notionnext-org/NotionNext/blob/main/conf/widget.config.js)` 中调整（或在部署后台配置环境变量 `NEXT_PUBLIC_THEME_SWITCH`）：
 
 ```JavaScript
 THEME_SWITCH: process.env.NEXT_PUBLIC_THEME_SWITCH || false, // 是否显示切换主题按钮；预览站常开便于体验

--- a/docs/user-guide/themes/proxio.md
+++ b/docs/user-guide/themes/proxio.md
@@ -27,7 +27,7 @@
 
 - 将NotionNext当前主题配置为proxio即可
 
-- 主题所有的配置文件可以在 [/themes/proxio/config.js](https://github.com/tangly1024/NotionNext/blob/main/themes/proxio/config.js) 中找到。
+- 主题所有的配置文件可以在 [/themes/proxio/config.js](https://github.com/notionnext-org/NotionNext/blob/main/themes/proxio/config.js) 中找到。
 
 ## Proxio 主题调色
 

--- a/docs/user-guide/themes/starter.md
+++ b/docs/user-guide/themes/starter.md
@@ -136,7 +136,7 @@ STARTER_COLOR_TEXT_MUTED: '#637381'
   STARTER_HERO_BUTTON_1_TEXT: '开始体验', // 英雄区按钮
   STARTER_HERO_BUTTON_1_URL: '/user-guide/deploy-vercel', // 英雄区按钮
   STARTER_HERO_BUTTON_2_TEXT: '在Github上关注', // 英雄区按钮
-  STARTER_HERO_BUTTON_2_URL: 'https://github.com/tangly1024/NotionNext', // 英雄区按钮
+  STARTER_HERO_BUTTON_2_URL: 'https://github.com/notionnext-org/NotionNext', // 英雄区按钮
   STARTER_HERO_PREVIEW_IMAGE: '/images/starter/hero/hero-image.webp', // 产品预览图 ，默认读取public目录下图片； 您可以上传自己的图片至/public/starter/hero目录下；
 ```
 
@@ -174,7 +174,7 @@ STARTER_COLOR_TEXT_MUTED: '#637381'
   STARTER_FEATURE_1_TITLE_1: '免费且开源', // 特性1
   STARTER_FEATURE_1_TEXT_1: '项目源码在Github上完全开放共享，遵循MIT协议', // 特性1
   STARTER_FEATURE_1_BUTTON_TEXT: '了解更多', // 特性1
-  STARTER_FEATURE_1_BUTTON_URL: 'https://github.com/tangly1024/NotionNext', // 特性1
+  STARTER_FEATURE_1_BUTTON_URL: 'https://github.com/notionnext-org/NotionNext', // 特性1
 
   STARTER_FEATURE_2_TITLE_1: '多种主题定制', // 特性2
   STARTER_FEATURE_2_TEXT_1: '数十种主题,适用于不同场景，总有一款适合你', // 特性2
@@ -352,7 +352,7 @@ STARTER_TESTIMONIALS_TITLE: '用户反馈',
 ```JavaScript
 STARTER_TEAM_TITLE: '团队成员',
   STARTER_TEAM_TEXT_1: '我们的开发者团队',
-  STARTER_TEAM_TEXT_2: 'NotionNext 由众多开源技术爱好者们共同合作完成，感谢每一位&lt;a className="underline" href="https://github.com/tangly1024/NotionNext/graphs/contributors"&gt;贡献者&lt;/a&gt;',
+  STARTER_TEAM_TEXT_2: 'NotionNext 由众多开源技术爱好者们共同合作完成，感谢每一位&lt;a className="underline" href="https://github.com/notionnext-org/NotionNext/graphs/contributors"&gt;贡献者&lt;/a&gt;',
 
   // 这里不支持CONFIG和环境变量，需要一一修改此处代码。
   STARTER_TEAM_ITEMS: [

--- a/docs/user-guide/update.md
+++ b/docs/user-guide/update.md
@@ -32,7 +32,7 @@
 
 本项目在长期维护更新中，不时将修复一些bug和增加新特性。新版本中对页面样式以及加载速度都做了大量的优化，因此推荐您更新到最新版。
 
-您可以在[NotionNext的Github仓库](https://github.com/tangly1024/NotionNext)右上角点击Star，以便关注项目动态，您将第一时间收到新版本发布的消息。
+您可以在[NotionNext的Github仓库](https://github.com/notionnext-org/NotionNext)右上角点击Star，以便关注项目动态，您将第一时间收到新版本发布的消息。
 
 ![Untitled](/legacy/5c03aa929431ec11.png)
 
@@ -200,11 +200,11 @@ NotionNext更新冲突？网上教程还要VS code和git?通通不需要，马�
 
 ## Github 自动化（高阶方法，需要一定知识）
 
-除了手动点击 `Fetch upstream` / `Sync fork` 按钮，仓库内置了一个 GitHub Actions workflow（[`.github/workflows/sync.yaml`](https://github.com/tangly1024/NotionNext/blob/main/.github/workflows/sync.yaml)），可以自动帮你完成每日同步上游最新代码的工作。
+除了手动点击 `Fetch upstream` / `Sync fork` 按钮，仓库内置了一个 GitHub Actions workflow（[`.github/workflows/sync.yaml`](https://github.com/notionnext-org/NotionNext/blob/main/.github/workflows/sync.yaml)），可以自动帮你完成每日同步上游最新代码的工作。
 
 ### 功能说明
 
-该 workflow 每天 UTC 0点（对应北京时间早上8点）自动运行一次，将上游仓库 `tangly1024/NotionNext` 的 `main` 分支同步合并到你 fork 仓库的 `main` 分支，不需要每天手动点击更新按钮。
+该 workflow 每天 UTC 0点（对应北京时间早上8点）自动运行一次，将上游仓库 `notionnext-org/NotionNext` 的 `main` 分支同步合并到你 fork 仓库的 `main` 分支，不需要每天手动点击更新按钮。
 
 关键配置如下：
 
@@ -220,7 +220,7 @@ jobs:
     steps:
       - uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
         with:
-          upstream_sync_repo: tangly1024/NotionNext
+          upstream_sync_repo: notionnext-org/NotionNext
           upstream_sync_branch: main
           target_sync_branch: main
 ```

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "notion-next",
   "version": "4.10.10",
   "packageManager": "yarn@1.22.22",
-  "homepage": "https://github.com/tangly1024/NotionNext.git",
+  "homepage": "https://github.com/notionnext-org/NotionNext.git",
   "license": "MIT",
   "engines": {
     "node": ">=22 <25"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangly1024/NotionNext.git"
+    "url": "https://github.com/notionnext-org/NotionNext.git"
   },
   "author": {
     "name": "tangly",
@@ -150,7 +150,7 @@
     "uuid": "^11.1.1"
   },
   "bugs": {
-    "url": "https://github.com/tangly/NotionNext/issues",
+    "url": "https://github.com/notionnext-org/NotionNext/issues",
     "email": "tlyong1992@hotmail.com"
   }
 }

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -61,7 +61,7 @@ check_prerequisites() {
     # 检查upstream远程仓库是否存在
     if ! git remote | grep -q "^upstream$"; then
         print_warning "未找到upstream远程仓库，正在添加..."
-        git remote add upstream https://github.com/tangly1024/NotionNext.git
+        git remote add upstream https://github.com/notionnext-org/NotionNext.git
         print_success "upstream远程仓库已添加"
     fi
     

--- a/themes/landing/components/Footer.js
+++ b/themes/landing/components/Footer.js
@@ -162,7 +162,7 @@ export default function Footer() {
               </a>
             </li> */}
                         <li className="ml-4">
-                            <a href="https://github.com/tangly1024/NotionNext" className="flex justify-center items-center text-gray-600 hover:text-gray-900 bg-white hover:bg-white-100 rounded-full shadow transition duration-150 ease-in-out" aria-label="Github">
+                            <a href="https://github.com/notionnext-org/NotionNext" className="flex justify-center items-center text-gray-600 hover:text-gray-900 bg-white hover:bg-white-100 rounded-full shadow transition duration-150 ease-in-out" aria-label="Github">
                                 <svg className="w-8 h-8 fill-current" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
                                     <path d="M16 8.2c-4.4 0-8 3.6-8 8 0 3.5 2.3 6.5 5.5 7.6.4.1.5-.2.5-.4V22c-2.2.5-2.7-1-2.7-1-.4-.9-.9-1.2-.9-1.2-.7-.5.1-.5.1-.5.8.1 1.2.8 1.2.8.7 1.3 1.9.9 2.3.7.1-.5.3-.9.5-1.1-1.8-.2-3.6-.9-3.6-4 0-.9.3-1.6.8-2.1-.1-.2-.4-1 .1-2.1 0 0 .7-.2 2.2.8.6-.2 1.3-.3 2-.3s1.4.1 2 .3c1.5-1 2.2-.8 2.2-.8.4 1.1.2 1.9.1 2.1.5.6.8 1.3.8 2.1 0 3.1-1.9 3.7-3.7 3.9.3.4.6.9.6 1.6v2.2c0 .2.1.5.6.4 3.2-1.1 5.5-4.1 5.5-7.6-.1-4.4-3.7-8-8.1-8z" />
                                 </svg>

--- a/themes/landing/config.js
+++ b/themes/landing/config.js
@@ -3,7 +3,7 @@ const CONFIG = {
 
 
   LANDING_HEADER_BUTTON_1_TITLE: 'Github开源',
-  LANDING_HEADER_BUTTON_1_URL: 'https://github.com/tangly1024/NotionNext',
+  LANDING_HEADER_BUTTON_1_URL: 'https://github.com/notionnext-org/NotionNext',
 
   LANDING_HEADER_BUTTON_2_TITLE: '作者博客',
   LANDING_HEADER_BUTTON_2_URL: 'https://blog.tangly1024.com/',

--- a/themes/magzine/config.js
+++ b/themes/magzine/config.js
@@ -61,18 +61,18 @@ const CONFIG = {
     {
       name: '开发者',
       menus: [
-        { title: 'Github', href: 'https://github.com/tangly1024/NotionNext' },
+        { title: 'Github', href: 'https://github.com/notionnext-org/NotionNext' },
         {
           title: '开发帮助',
           href: 'https://docs.tangly1024.com/article/how-to-develop-with-notion-next'
         },
         {
           title: '功能反馈',
-          href: 'https://github.com/tangly1024/NotionNext/issues/new/choose'
+          href: 'https://github.com/notionnext-org/NotionNext/issues/new/choose'
         },
         {
           title: '技术讨论',
-          href: 'https://github.com/tangly1024/NotionNext/discussions'
+          href: 'https://github.com/notionnext-org/NotionNext/discussions'
         },
         {
           title: '关于作者',

--- a/themes/proxio/config.js
+++ b/themes/proxio/config.js
@@ -20,7 +20,7 @@ const CONFIG = {
   PROXIO_HERO_BUTTON_1_URL:
     'https://docs.tangly1024.com/article/vercel-deploy-notion-next', // 英雄区按钮
   PROXIO_HERO_BUTTON_2_TEXT: '在Github上关注', // 英雄区按钮
-  PROXIO_HERO_BUTTON_2_URL: 'https://github.com/tangly1024/NotionNext', // 英雄区按钮
+  PROXIO_HERO_BUTTON_2_URL: 'https://github.com/notionnext-org/NotionNext', // 英雄区按钮
   PROXIO_HERO_BUTTON_2_ICON: '/images/starter/github-mark.svg', // 英雄区按钮2的图标，不需要则留空
 
   // 英雄区配图，如需隐藏，改为空值即可 ''
@@ -67,7 +67,7 @@ const CONFIG = {
     '精益求精雕琢每个元素，确保成品精致统一，令人过目难忘',
 
   PROXIO_FEATURE_BUTTON_TEXT: '了解更多', // 按钮文字
-  PROXIO_FEATURE_BUTTON_URL: 'https://github.com/tangly1024/NotionNext', // 按钮跳转
+  PROXIO_FEATURE_BUTTON_URL: 'https://github.com/notionnext-org/NotionNext', // 按钮跳转
 
   // 首页生涯区块
   PROXIO_CAREER_ENABLE: true, // 区块开关
@@ -231,18 +231,18 @@ const CONFIG = {
     {
       name: '开发者',
       menus: [
-        { title: 'Github', href: 'https://github.com/tangly1024/NotionNext' },
+        { title: 'Github', href: 'https://github.com/notionnext-org/NotionNext' },
         {
           title: '开发帮助',
           href: 'https://docs.tangly1024.com/article/how-to-develop-with-notion-next'
         },
         {
           title: '功能反馈',
-          href: 'https://github.com/tangly1024/NotionNext/issues/new/choose'
+          href: 'https://github.com/notionnext-org/NotionNext/issues/new/choose'
         },
         {
           title: '技术讨论',
-          href: 'https://github.com/tangly1024/NotionNext/discussions'
+          href: 'https://github.com/notionnext-org/NotionNext/discussions'
         },
         {
           title: '关于作者',

--- a/themes/starter/components/Footer.js
+++ b/themes/starter/components/Footer.js
@@ -134,7 +134,7 @@ export const Footer = props => {
                   <p className='text-base text-gray-7'>
                     Designed and Developed by
                     <a
-                      href='https://github.com/tangly1024/NotionNext'
+                      href='https://github.com/notionnext-org/NotionNext'
                       rel='nofollow noopner noreferrer'
                       target='_blank'
                       className='px-1 text-gray-1 hover:underline'>

--- a/themes/starter/config.js
+++ b/themes/starter/config.js
@@ -23,7 +23,7 @@ const CONFIG = {
   STARTER_HERO_BUTTON_1_TEXT: '开始体验', // 英雄区按钮
   STARTER_HERO_BUTTON_1_URL: 'https://notionnext.tangly1024.com/', // 英雄区按钮
   STARTER_HERO_BUTTON_2_TEXT: '在Github上关注', // 英雄区按钮
-  STARTER_HERO_BUTTON_2_URL: 'https://github.com/tangly1024/NotionNext', // 英雄区按钮
+  STARTER_HERO_BUTTON_2_URL: 'https://github.com/notionnext-org/NotionNext', // 英雄区按钮
   STARTER_HERO_BUTTON_2_ICON: '/images/starter/github.svg', // 英雄区按钮2的图标，不需要则留空
 
   // 英雄区配图，如需隐藏，改为空值即可 ''
@@ -47,7 +47,7 @@ const CONFIG = {
   STARTER_FEATURE_1_TITLE_1: '免费且开源', // 特性1
   STARTER_FEATURE_1_TEXT_1: '项目源码在Github上完全开放共享，遵循MIT协议', // 特性1
   STARTER_FEATURE_1_BUTTON_TEXT: '了解更多', // 特性1
-  STARTER_FEATURE_1_BUTTON_URL: 'https://github.com/tangly1024/NotionNext', // 特性1
+  STARTER_FEATURE_1_BUTTON_URL: 'https://github.com/notionnext-org/NotionNext', // 特性1
 
   STARTER_FEATURE_2_TITLE_1: '多种主题定制', // 特性2
   STARTER_FEATURE_2_TEXT_1: '数十种主题,适用于不同场景，总有一款适合你', // 特性2
@@ -208,7 +208,7 @@ const CONFIG = {
   STARTER_TEAM_TITLE: '团队成员',
   STARTER_TEAM_TEXT_1: '我们的开发者团队',
   STARTER_TEAM_TEXT_2:
-    'NotionNext 由众多开源技术爱好者们共同合作完成，感谢每一位<a className="underline" href="https://github.com/tangly1024/NotionNext/graphs/contributors">贡献者</a>',
+    'NotionNext 由众多开源技术爱好者们共同合作完成，感谢每一位<a className="underline" href="https://github.com/notionnext-org/NotionNext/graphs/contributors">贡献者</a>',
 
   // 这里不支持CONFIG和环境变量，需要一一修改此处代码。
   STARTER_TEAM_ITEMS: [


### PR DESCRIPTION
Resolves #4450

## 已知问题

1. NotionNext 已迁移至 `notionnext-org/NotionNext`，但仓库中仍存在部分旧地址：

   - `tangly1024/NotionNext`
   - `tangly/NotionNext`
2. 旧地址分布在项目元数据、GitHub Actions、更新脚本、主题配置及当前维护中的文档中。

## 解决方案

1. 将仍代表当前 NotionNext 官方仓库的地址统一更新为：`notionnext-org/NotionNext`

2. 更新范围包括：

   - `package.json` 中的 `homepage`、`repository.url`、`bugs.url`
   - `.github/workflows/sync.yaml` 中的 upstream repository
   - `scripts/update.sh` 中的 upstream URL
   - `conf/*.config.js` 中的仓库示例和 Issue 链接
   - 部分主题 Footer、GitHub、Issues、Discussions、Contributors 等链接
   - `docs/developer/` 和 `docs/user-guide/` 中仍指向旧仓库的当前文档链接

3. 保留以下内容不变：

   - `docs/user-guide/changelog/v3-history.md`
   - `docs/user-guide/changelog/v4-history.md`
   - `@tangly1024`、`assignees=tangly1024` 等个人 GitHub 身份信息
   - `tangly1024.com`、`docs.tangly1024.com`、`preview.tangly1024.com` 等独立域名
   - 文档中的「迁移自」和「原文链接」

## 改动收益

1. 当前项目统一使用 `notionnext-org/NotionNext` 作为官方仓库地址。
2. 减少对 GitHub 旧仓库重定向的依赖。
3. Fork 同步、更新脚本和项目元数据直接使用当前仓库。
4. 保持当前文档中的 GitHub 链接与项目实际归属一致。

## 具体改动

1. 共修改 **44 个文件**，更新 **114 处**旧仓库标识。

2. 代码和配置：

   - `.github/workflows/sync.yaml`
   - `package.json`
   - `scripts/update.sh`
   - `conf/analytics.config.js`
   - `conf/comment.config.js`
   - `themes/landing/*`
   - `themes/magzine/config.js`
   - `themes/proxio/config.js`
   - `themes/starter/*`

3. 文档：

   - 更新 `docs/developer/` 中相关仓库及 upstream 地址
   - 更新 `docs/user-guide/` 中的仓库、源码、Issue、PR、Release、Discussion、Fork、Compare 等链接

4. 未修改：

   - `docs/user-guide/changelog/v3-history.md`
   - `docs/user-guide/changelog/v4-history.md`

   两个历史 Changelog 中共保留 **806 处**旧仓库引用。

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] （如适用）版本号正确显示
- [x] （如适用）环境变量配置正常工作
- [x] Patch 已通过 `git apply --check`
- [x] 已通过 `git diff --check`
- [x] 已全文检查 `(tangly1024|tangly)/NotionNext`
- [x] 除两个历史 Changelog 外，无其他旧 NotionNext repository slug 残留

## 用户文档（`docs/user-guide/` / `docs/developer/`）

如果本 PR 新增或修改了站长会使用的功能、主题配置、环境变量、Notion Config 键、插件开关、部署步骤、默认行为或可见 UI 交互，请同步更新 `docs/user-guide/` 或 `docs/developer/` 中对应说明，并在下方勾选已完成项。

只有纯内部重构、测试、CI、依赖维护、拼写修正等不改变站长使用方式的改动，才可以勾选「不适用」。

- [ ] 不适用（无文档改动）
- [x] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [x] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（本 PR 未新增/移动文章）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md) （本PR 无新 slug 或路径变更）
- [x] 环境变量名与 `conf/*.config.js` 一致（未修改环境变量名）
- [x] 示例中无真实 Token、`.env`、私有 ID
- [x] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明：本 PR 仅更新现有文档中的旧 GitHub 仓库地址，没有新增、移动或重命名文档，也没有修改 slug。