### PR TITLE
feat(heo): add accessible day-night toggle

### DIFF
--- a/__tests__/themes/heo/DarkModeButton.test.js
+++ b/__tests__/themes/heo/DarkModeButton.test.js
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import DarkModeButton from '@/themes/heo/components/DarkModeButton'
+import { useGlobal } from '@/lib/global'
+
+jest.mock('@/lib/global', () => ({
+  useGlobal: jest.fn()
+}))
+
+describe('HEO DarkModeButton', () => {
+  const toggleDarkMode = jest.fn()
+
+  beforeEach(() => {
+    useGlobal.mockReturnValue({
+      isDarkMode: false,
+      toggleDarkMode
+    })
+  })
+
+  it('exposes the next mode and toggles exactly once', () => {
+    render(<DarkModeButton />)
+
+    const button = screen.getByRole('button', {
+      name: 'Switch to dark mode'
+    })
+    expect(button).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(button)
+
+    expect(toggleDarkMode).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a localized drawer label without nesting controls', () => {
+    useGlobal.mockReturnValue({
+      isDarkMode: true,
+      toggleDarkMode
+    })
+
+    const { container } = render(<DarkModeButton label='Light mode' />)
+
+    expect(
+      screen.getByRole('button', { name: 'Switch to light mode' })
+    ).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('Light mode')).toBeInTheDocument()
+    expect(container.querySelectorAll('button')).toHaveLength(1)
+  })
+})

--- a/themes/heo/components/DarkModeButton.js
+++ b/themes/heo/components/DarkModeButton.js
@@ -1,38 +1,50 @@
-import { useGlobal } from '@/lib/global'
-import { saveDarkModeToLocalStorage } from '@/themes/theme'
 import { Moon, Sun } from '@/components/HeroIcons'
-import { useImperativeHandle } from 'react'
+import { useGlobal } from '@/lib/global'
 
 /**
- * 深色模式按钮
+ * HEO day/night toggle. Theme state and persistence remain owned by useGlobal.
  */
-const DarkModeButton = (props) => {
-  const { cRef, className } = props
-  const { isDarkMode, updateDarkMode } = useGlobal()
+const DarkModeButton = ({ className = '', label }) => {
+  const { isDarkMode, locale, toggleDarkMode } = useGlobal()
+  const actionLabel = isDarkMode
+    ? locale?.MENU?.LIGHT_MODE || 'Switch to light mode'
+    : locale?.MENU?.DARK_MODE || 'Switch to dark mode'
+  const labelledButton = Boolean(label)
 
-  /**
-   * 对外暴露方法
-   */
-  useImperativeHandle(cRef, () => {
-    return {
-      handleChangeDarkMode: () => {
-        handleChangeDarkMode()
-      }
-    }
-  })
-
-  // 用户手动设置主题
-  const handleChangeDarkMode = () => {
-    const newStatus = !isDarkMode
-    saveDarkModeToLocalStorage(newStatus)
-    updateDarkMode(newStatus)
-    const htmlElement = document.getElementsByTagName('html')[0]
-    htmlElement.classList?.remove(newStatus ? 'light' : 'dark')
-    htmlElement.classList?.add(newStatus ? 'dark' : 'light')
-  }
-
-  return <div onClick={handleChangeDarkMode} className={`${className || ''} cursor-pointer hover: scale-100 hover:bg-black hover:bg-opacity-10 rounded-full w-10 h-10 flex justify-center items-center duration-200 transition-all`}>
-    <div id='darkModeButton' className=' cursor-pointer hover: scale-50 w-10 h-10 '> {isDarkMode ? <Sun /> : <Moon />}</div>
-  </div>
+  return (
+    <button
+      type='button'
+      onClick={toggleDarkMode}
+      aria-label={actionLabel}
+      aria-pressed={isDarkMode}
+      title={actionLabel}
+      className={`${className} group flex cursor-pointer items-center rounded-lg transition-colors duration-200 motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--heo-color-border)] focus-visible:ring-offset-2 dark:focus-visible:ring-[var(--heo-color-border-dark)] dark:focus-visible:ring-offset-[var(--heo-color-bg-dark)] ${
+        labelledButton
+          ? 'w-full justify-between border px-2 py-2 hover:bg-[var(--heo-color-primary)] hover:text-[var(--heo-color-primary-text)] hover:shadow-md dark:border-gray-600 dark:bg-[var(--heo-color-card-dark)] dark:hover:bg-[var(--heo-color-accent)] dark:hover:text-white'
+          : 'h-10 w-10 justify-center hover:bg-black hover:bg-opacity-10'
+      }`}
+    >
+      {label && <span>{label}</span>}
+      <span
+        aria-hidden='true'
+        className={`relative inline-flex h-6 w-10 flex-shrink-0 items-center rounded-full border shadow-inner transition-colors duration-200 motion-reduce:transition-none ${
+          isDarkMode
+            ? 'border-[var(--heo-color-border-dark)] bg-slate-800'
+            : 'border-[var(--heo-color-border)] bg-indigo-100'
+        }`}
+      >
+        <span
+          className={`absolute flex h-5 w-5 items-center justify-center rounded-full shadow-sm transition-transform duration-200 motion-reduce:transition-none ${
+            isDarkMode
+              ? 'translate-x-[18px] bg-[var(--heo-color-accent)] text-[#18171d]'
+              : 'translate-x-[1px] bg-white text-[var(--heo-color-primary)]'
+          }`}
+        >
+          <span className='h-3.5 w-3.5'>{isDarkMode ? <Moon /> : <Sun />}</span>
+        </span>
+      </span>
+    </button>
+  )
 }
+
 export default DarkModeButton

--- a/themes/heo/components/SlideOver.js
+++ b/themes/heo/components/SlideOver.js
@@ -1,4 +1,3 @@
-import DarkModeButton from '@/components/DarkModeButton'
 import { useGlobal } from '@/lib/global'
 import { Dialog, Transition } from '@headlessui/react'
 import SmartLink from '@/components/SmartLink'
@@ -11,6 +10,7 @@ import {
   useState
 } from 'react'
 import { MenuListSide } from './MenuListSide'
+import DarkModeButton from './DarkModeButton'
 import TagGroups from './TagGroups'
 
 /**
@@ -126,21 +126,11 @@ export default function SlideOver(props) {
  * 一个包含图标的按钮
  */
 function DarkModeBlockButton() {
-  const darkModeRef = useRef()
   const { isDarkMode, locale } = useGlobal()
-
-  function handleChangeDarkMode() {
-    darkModeRef?.current?.handleChangeDarkMode()
-  }
   return (
-    <button
-      onClick={handleChangeDarkMode}
-      className={
-        'group duration-200 hover:text-[var(--heo-color-primary-text)] hover:shadow-md hover:bg-[var(--heo-color-primary)] flex justify-between items-center px-2 py-2 border dark:border-gray-600 bg-[var(--heo-color-card)] dark:bg-[var(--heo-color-accent)] rounded-lg'
-      }>
-      <DarkModeButton cRef={darkModeRef} className='group-hover:text-white' />{' '}
-      {isDarkMode ? locale.MENU.LIGHT_MODE : locale.MENU.DARK_MODE}
-    </button>
+    <DarkModeButton
+      label={isDarkMode ? locale.MENU.LIGHT_MODE : locale.MENU.DARK_MODE}
+    />
   )
 }
 


### PR DESCRIPTION
## Summary

- replace the HEO theme dark-mode icon with a fixed-size day/night switch using the existing global state and persistence path
- use one native button in both the desktop header and mobile drawer, preventing the drawer icon from bubbling into a second toggle
- add localized accessible naming, visible keyboard focus, stable dimensions, and reduced-motion handling
- add focused regression tests for the light/dark semantics and single-toggle behavior

This is intentionally scoped to one theme, following the maintainer guidance in #2236. No external assets or copied toggle code are included.

## Validation

- `git diff --check`
- changed component and test formatted with Prettier; updated drawer source parses successfully
- focused Jest test added at `__tests__/themes/heo/DarkModeButton.test.js`
- full local Jest/lint/type-check were blocked because dependency installation hit `ENOSPC`, followed by `ENETUNREACH`; repository CI is the verification source for this draft

## Screenshots

Desktop/mobile light/dark screenshots will be added after the preview or local dependency environment is available.

Related to #2236