### PR TITLE
feat(simple): add site traffic stats to header and footer

### DIFF
--- a/docs/user-guide/themes/simple.md
+++ b/docs/user-guide/themes/simple.md
@@ -1,7 +1,7 @@
 # Simple主题
 > 迁移自：[Simple主题](https://docs.tangly1024.com/article/notionnext-simple)
 > 发布日期：2024-3-19
-> 最后编辑：2025-7-7
+> 最后编辑：2026-8-27
 > 原栏目：⭐ 主题参数
 
 
@@ -54,6 +54,21 @@ const CONFIG = {
 }
 export default CONFIG
 ```
+
+
+### 不蒜子访问统计
+
+Simple 主题支持复用全局 `ANALYTICS_BUSUANZI_ENABLE` 配置展示不蒜子访问统计。
+
+开启后：
+
+- Header 显示站点访问量和访客数：`访问量 xxx · 访客数 xxx`
+- Footer 显示图标形式的站点访问量和访客数
+- Header 和 Footer 均使用站点级的 `site_pv` 和 `site_uv` 数据
+
+关闭 `ANALYTICS_BUSUANZI_ENABLE` 后，Header 和 Footer 均不展示上述统计信息。
+
+更多统计配置见 [站点统计相关](../analytics/overview.md)。
 
 
 ## FAQ

--- a/themes/simple/components/Footer.js
+++ b/themes/simple/components/Footer.js
@@ -1,3 +1,4 @@
+import AnalyticsBusuanzi from '@/components/AnalyticsBusuanzi'
 import { BeiAnGongAn } from '@/components/BeiAnGongAn'
 import DarkModeButton from '@/components/DarkModeButton'
 import { siteConfig } from '@/lib/config'
@@ -11,6 +12,7 @@ export default function Footer(props) {
   const d = new Date()
   const currentYear = d.getFullYear()
   const since = siteConfig('SINCE')
+  const ANALYTICS_BUSUANZI_ENABLE = siteConfig('ANALYTICS_BUSUANZI_ENABLE')
   const copyrightDate =
     parseInt(since) < currentYear ? since + '-' + currentYear : currentYear
 
@@ -34,6 +36,11 @@ export default function Footer(props) {
             </a>
           )}
           <BeiAnGongAn />
+          {ANALYTICS_BUSUANZI_ENABLE && (
+            <div className='inline-flex ml-4'>
+              <AnalyticsBusuanzi />
+            </div>
+          )}
           <span className='no-underline ml-4'>
             Powered by
             <a

--- a/themes/simple/components/Header.js
+++ b/themes/simple/components/Header.js
@@ -10,6 +10,7 @@ import SocialButton from './SocialButton'
  */
 export default function Header(props) {
   const { siteInfo } = props
+  const ANALYTICS_BUSUANZI_ENABLE = siteConfig('ANALYTICS_BUSUANZI_ENABLE')
 
   return (
     <header className='text-center justify-between items-center px-6 bg-white h-80 dark:bg-black relative z-10'>
@@ -41,6 +42,18 @@ export default function Header(props) {
             </div>
           </div>
         </SmartLink>
+
+        {ANALYTICS_BUSUANZI_ENABLE && (
+          <div className='flex justify-center mt-2 text-sm text-gray-500 dark:text-gray-300'>
+            <span className='hidden busuanzi_container_site_pv whitespace-nowrap'>
+              访问量 <span className='busuanzi_value_site_pv' />
+            </span>
+            <span className='hidden busuanzi_container_site_uv whitespace-nowrap'>
+              <span className='mx-1'>·</span>
+              访客数 <span className='busuanzi_value_site_uv' />
+            </span>
+          </div>
+        )}
 
         <div className='flex justify-center'>
           <SocialButton />


### PR DESCRIPTION
Resolves #2958 

## 已知问题

1. Simple 主题目前缺少站点访问统计展示

   - 开启 `ANALYTICS_BUSUANZI_ENABLE` 后，Simple 主题 Header 和 Footer 未展示站点访问量、访客数
   - 其他部分主题已经提供类似的站点统计信息，Simple 主题在这方面表现不一致

## 解决方案

1. 在 Simple 主题 Header 中增加站点访问统计

   - 复用现有 `ANALYTICS_BUSUANZI_ENABLE` 配置控制是否展示
   - 使用 Busuanzi 的 `site_pv` 和 `site_uv` 数据
   - 采用文字形式展示：`访问量 xxx · 访客数 xxx`

2. 在 Simple 主题 Footer 中增加站点访问统计

   - 复用现有公共组件 `AnalyticsBusuanzi`
   - 复用 `ANALYTICS_BUSUANZI_ENABLE` 配置控制是否展示
   - 保持公共组件现有的图标展示形式

3. 保持改动范围最小

   - 不修改 `components/AnalyticsBusuanzi.js`
   - 不新增主题配置项
   - 不修改 Busuanzi 的加载和统计逻辑
   - 不影响其他主题

## 改动收益

1. 完善 Simple 主题的站点统计展示

   - Header 可直接查看站点访问量和访客数
   - Footer 与其他使用 `AnalyticsBusuanzi` 的位置保持一致

2. 复用现有配置和组件

   - 无需新增环境变量或主题配置
   - 用户仍然只需要通过 `ANALYTICS_BUSUANZI_ENABLE` 控制 Busuanzi 的启用状态

3. 保持统计口径一致

   - Header 和 Footer 均使用站点级别的 `site_pv` / `site_uv`
   - 避免将单页面 `page_pv` 与站点总访问量混用

## 具体改动

1. `themes/simple/components/Header.js`

   - 读取现有 `ANALYTICS_BUSUANZI_ENABLE` 配置
   - 开启 Busuanzi 时展示站点访问量和访客数
   - 使用 `busuanzi_value_site_pv` 和 `busuanzi_value_site_uv`
   - 展示形式为：`访问量 xxx · 访客数 xxx`

2. `themes/simple/components/Footer.js`

   - 引入现有 `AnalyticsBusuanzi` 公共组件
   - 读取现有 `ANALYTICS_BUSUANZI_ENABLE` 配置
   - 开启 Busuanzi 时展示现有图标形式的站点访问量和访客数

3. `docs/user-guide/themes/simple.md`

   - 补充 Simple 主题不蒜子访问统计说明
   - 说明 Header 和 Footer 在开启 `ANALYTICS_BUSUANZI_ENABLE` 后的展示效果
   - 明确 Header 和 Footer 均使用站点级 `site_pv` 和 `site_uv` 数据

## 效果截图

### `ANALYTICS_BUSUANZI_ENABLE = true`

#### Header

<img width="495" height="390" alt="开启 Busuanzi 后的 Simple Header" src="https://github.com/user-attachments/assets/f8bcec90-b2b0-48a9-b3bd-ea625982be61" />

#### Footer

<img width="1407" height="142" alt="开启 Busuanzi 后的 Simple Footer" src="https://github.com/user-attachments/assets/abd731b9-1147-47a2-abba-8713c012c88b" />

### `ANALYTICS_BUSUANZI_ENABLE = false`

#### Header

<img width="664" height="441" alt="关闭 Busuanzi 后的 Simple Header" src="https://github.com/user-attachments/assets/19e523d4-727d-44dc-80ff-507fadb5f554" />

#### Footer

<img width="1367" height="147" alt="关闭 Busuanzi 后的 Simple Footer" src="https://github.com/user-attachments/assets/c589807e-d566-48d0-995b-99b365d115f3" />

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] `ANALYTICS_BUSUANZI_ENABLE = true` 时 Header 正常显示访问量和访客数
- [x] `ANALYTICS_BUSUANZI_ENABLE = true` 时 Footer 正常显示访问量和访客数
- [x] `ANALYTICS_BUSUANZI_ENABLE = false` 时 Header 不显示访问统计
- [x] `ANALYTICS_BUSUANZI_ENABLE = false` 时 Footer 不显示访问统计
- [x] Header 与 Footer 的 `site_pv` / `site_uv` 数据保持一致
- [x] 未影响 Simple 主题其他 Header / Footer 内容及布局
- [x] 未影响其他主题

## 用户文档（`docs/user-guide/` / `docs/developer/`）

如果本 PR 新增或修改了站长会使用的功能、主题配置、环境变量、Notion Config 键、插件开关、部署步骤、默认行为或可见 UI 交互，请同步更新 `docs/user-guide/` 或 `docs/developer/` 中对应说明，并在下方勾选已完成项。

只有纯内部重构、测试、CI、依赖维护、拼写修正等不改变站长使用方式的改动，才可以勾选「不适用」。

- [ ] 不适用（无文档改动）
- [x] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [x] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [x] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [x] 示例中无真实 Token、`.env`、私有 ID
- [x] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明（可选）：本次改动复用已有 `ANALYTICS_BUSUANZI_ENABLE` 配置，不新增环境变量、主题配置或 Notion Config 键。