### PR TITLE
Claude/website missing issue vnf1vx

### DIFF
--- a/conf/font.config.js
+++ b/conf/font.config.js
@@ -6,13 +6,13 @@ module.exports = {
   // START ************网站字体*****************
   // ['font-serif','font-sans'] 两种可选，分别是衬线和无衬线: 参考 https://www.jianshu.com/p/55e410bd2115
   // 后面空格隔开的font-light的字体粗细，留空是默认粗细；参考 https://www.tailwindcss.cn/docs/font-weight
-  FONT_STYLE: process.env.NEXT_PUBLIC_FONT_STYLE || 'font-sans font-light',
+  FONT_STYLE: process.env.NEXT_PUBLIC_FONT_STYLE || 'font-sans',
   // 字体CSS 例如 https://npm.elemecdn.com/lxgw-wenkai-webfont@1.6.0/style.css
   FONT_URL: process.env.NEXT_PUBLIC_FONT_URL || [
     // 'https://npm.elemecdn.com/lxgw-wenkai-webfont@1.6.0/style.css',
         'https://fonts.googleapis.com/css2?family=Iansui&display=swap',
     'https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap',
-    'https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@300;400;500;700&display=swap'
+        'https://fonts.googleapis.com/css2?family=Noto+Serif+TC:wght@400;500;700&display=swap',
   ],
 
   // 字体优化配置
@@ -43,6 +43,7 @@ module.exports = {
   // 衬线字体 例如'"LXGW WenKai"'
   FONT_SERIF: [
     // '"LXGW WenKai"',
+    '"Noto Serif TC"',
     'Bitter',
     '"Noto Serif SC"',
     'SimSun',

--- a/conf/font.config.js
+++ b/conf/font.config.js
@@ -10,7 +10,7 @@ module.exports = {
   // 字体CSS 例如 https://npm.elemecdn.com/lxgw-wenkai-webfont@1.6.0/style.css
   FONT_URL: process.env.NEXT_PUBLIC_FONT_URL || [
     // 'https://npm.elemecdn.com/lxgw-wenkai-webfont@1.6.0/style.css',
-    'https://fonts.googleapis.com/css?family=Bitter:300,400,700&display=swap',
+        'https://fonts.googleapis.com/css2?family=Iansui&display=swap',
     'https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap',
     'https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@300;400;500;700&display=swap'
   ],
@@ -22,6 +22,7 @@ module.exports = {
   // 无衬线字体 例如'"LXGW WenKai"'
   FONT_SANS: [
     // '"LXGW WenKai"',
+    '"Iansui"',
     '"PingFang SC"',
     '-apple-system',
     'BlinkMacSystemFont',

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -466,7 +466,9 @@ async function convertNotionToSiteData(
 
   if (!pageRecordMap) {
     console.error(`[${traceId}] can't get Notion Data ; pageId:`, SITE_DATABASE_PAGE_ID)
-    return {}
+    // 返回结构完整的空数据，而非 {}；否则下游字段为 undefined，
+    // getStaticProps 序列化失败会导致整站构建中断。
+    return EmptyData(SITE_DATABASE_PAGE_ID)
   }
 
   // const stepStart1 = Date.now()
@@ -754,14 +756,14 @@ function shortenIds(items) {
       }
     })
   }
-  return items
+  return []
 }
 
 function cleanIds(items) {
   if (items && Array.isArray(items)) {
     return items.map(({ id, ...rest }) => rest)
   }
-  return items
+  return []
 }
 
 function cleanTagOptions(tagOptions) {
@@ -770,7 +772,7 @@ function cleanTagOptions(tagOptions) {
       .filter(tagOption => tagOption.source === 'Published')
       .map(({ id, source, ...rest }) => rest)
   }
-  return tagOptions
+  return []
 }
 
 function cleanBlock(item) {

--- a/themes/hexo/components/BlogPostCard.js
+++ b/themes/hexo/components/BlogPostCard.js
@@ -26,7 +26,7 @@ const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
       <div
         key={post.id}
         id='blog-post-card'
-        className={`group md:h-56 w-full flex justify-between md:flex-row flex-col-reverse shadow-sm ${siteConfig('HEXO_POST_LIST_IMG_CROSSOVER', null, CONFIG) && index % 2 === 1 ? 'md:flex-row-reverse' : ''}
+        className={`group md:h-96 w-full flex justify-between md:flex-row flex-col-reverse shadow-sm ${siteConfig('HEXO_POST_LIST_IMG_CROSSOVER', null, CONFIG) && index % 2 === 1 ? 'md:flex-row-reverse' : ''}
                     overflow-hidden border dark:border-black rounded-xl bg-white dark:bg-hexo-black-gray`}>
         {/* 文字内容 */}
         <BlogPostCardInfo
@@ -46,7 +46,7 @@ const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
                   priority={index === 1}
                   alt={post?.title}
                   src={post?.pageCoverThumbnail}
-                  className='h-56 w-full object-cover object-center group-hover:scale-110 duration-500'
+                  className='h-96 w-full object-cover object-center group-hover:scale-110 duration-500'
                 />
               </>
             </SmartLink>

--- a/themes/hexo/components/Footer.js
+++ b/themes/hexo/components/Footer.js
@@ -11,7 +11,7 @@ const Footer = ({ title }) => {
     parseInt(since) < currentYear ? since + '-' + currentYear : currentYear
 
   return (
-    <footer className='relative z-10 dark:bg-black flex-shrink-0 bg-hexo-light-gray justify-center text-center m-auto w-full leading-6  text-gray-600 dark:text-gray-100 text-sm p-6'>
+    <footer className='relative z-10 dark:bg-black flex-shrink-0 bg-transparent justify-center text-center m-auto w-full leading-6  text-gray-600 dark:text-gray-100 text-sm p-6'>
       {/* <DarkModeButton/> */}
       <i className='fas fa-copyright' /> {`${copyrightDate}`}
       <span>

--- a/themes/hexo/components/TagItemMini.js
+++ b/themes/hexo/components/TagItemMini.js
@@ -3,19 +3,13 @@ import SmartLink from '@/components/SmartLink'
 const TagItemMini = ({ tag, selected = false }) => {
   return (
     <SmartLink
-      key={tag}
-      href={selected ? '/' : `/tag/${encodeURIComponent(tag.name)}`}
-      passHref
-      className={`cursor-pointer inline-block rounded hover:bg-indigo-400 dark:hover:text-white  hover:text-white duration-200
-        mr-2 py-0.5 px-1 text-xs whitespace-nowrap 
-         ${selected
-        ? 'text-white dark:text-gray-300 bg-black dark:bg-black dark:hover:bg-indigo-900'
-        : `text-gray-600 hover:shadow-xl dark:border-gray-400 notion-${tag.color}_background `}` }>
-
-      <div className='font-light'>{selected && <i className='mr-1 fa-tag'/>} {tag.name + (tag.count ? `(${tag.count})` : '')} </div>
-
-    </SmartLink>
-  );
+  key={tag}
+  href={selected ? '/' : `/tag/${encodeURIComponent(tag.name)}`}
+passHref
+className={`cursor-pointer inline-block rounded-md duration-200 mr-2 mb-1 py-1 px-2 text-xs whitespace-nowrap hover:bg-indigo-400 hover:text-white ${selected ? 'text-white bg-black' : 'text-gray-700 bg-gray-100 dark:bg-gray-800 dark:text-gray-300'}`}>
+<div className='font-medium'>#{tag.name}{tag.count ? `(${tag.count})` : ''}</div>
+  </SmartLink>
+)
 }
 
 export default TagItemMini

--- a/themes/hexo/config.js
+++ b/themes/hexo/config.js
@@ -1,5 +1,5 @@
 const CONFIG = {
-  HEXO_HOME_BANNER_ENABLE: true,
+  HEXO_HOME_BANNER_ENABLE: false,
   // 3.14.1以后的版本中，欢迎语在blog.config.js中配置，用英文逗号','隔开多个。
   HEXO_HOME_BANNER_GREETINGS: [
     'Hi，我是一个程序员',

--- a/themes/hexo/config.js
+++ b/themes/hexo/config.js
@@ -1,4 +1,4 @@
-  const CONFIG = {
+const CONFIG = {
       HEXO_HOME_BANNER_ENABLE: false,
   // 3.14.1以后的版本中，欢迎语在blog.config.js中配置，用英文逗号','隔开多个。
   HEXO_HOME_BANNER_GREETINGS: [
@@ -15,12 +15,12 @@
   HEXO_SHOW_START_READING: true,
 
   // 菜单配置
-  HEXO_MENU_INDEX: true, // 显示首页
-  HEXO_MENU_CATEGORY: true, // 显示分类
-  HEXO_MENU_TAG: true, // 显示标签
+      HEXO_MENU_INDEX: true,
+      HEXO_MENU_CATEGORY: true,
+      HEXO_MENU_TAG: true,
   HEXO_MENU_ARCHIVE: true, // 显示归档
   HEXO_MENU_SEARCH: true, // 显示搜索
-  HEXO_MENU_RANDOM: true, // 显示随机跳转按钮
+    HEXO_MENU_RANDOM: false,
 
   HEXO_POST_LIST_COVER: true, // 列表显示文章封面
   HEXO_POST_LIST_COVER_HOVER_ENLARGE: false, // 列表鼠标悬停放大
@@ -37,9 +37,9 @@
 
   HEXO_WIDGET_LATEST_POSTS: true, // 显示最新文章卡
   HEXO_WIDGET_ANALYTICS: false, // 显示统计卡
-  HEXO_WIDGET_TO_TOP: true,
-  HEXO_WIDGET_TO_COMMENT: true, // 跳到评论区
-  HEXO_WIDGET_DARK_MODE: true, // 夜间模式
+    HEXO_WIDGET_TO_TOP: false,
+    HEXO_WIDGET_TO_COMMENT: false,
+    HEXO_WIDGET_DARK_MODE: false,
   HEXO_WIDGET_TOC: true, // 移动端悬浮目录
 
     HEXO_COLOR_PRIMARY: '#8c7b75',

--- a/themes/hexo/config.js
+++ b/themes/hexo/config.js
@@ -1,5 +1,5 @@
-const CONFIG = {
-  HEXO_HOME_BANNER_ENABLE: false,
+  const CONFIG = {
+      HEXO_HOME_BANNER_ENABLE: false,
   // 3.14.1以后的版本中，欢迎语在blog.config.js中配置，用英文逗号','隔开多个。
   HEXO_HOME_BANNER_GREETINGS: [
     'Hi，我是一个程序员',
@@ -42,8 +42,8 @@ const CONFIG = {
   HEXO_WIDGET_DARK_MODE: true, // 夜间模式
   HEXO_WIDGET_TOC: true, // 移动端悬浮目录
 
-  HEXO_COLOR_PRIMARY: '#928CEE',
-  HEXO_THEME_COLOR: '#928CEE', // 主题色配置（默认为 #928CEE）
+    HEXO_COLOR_PRIMARY: '#8c7b75',
+    HEXO_THEME_COLOR: '#8c7b75', // 主題色
 
   /** 文章详情页客户端切换时，主栏显示卡片+转圈占位（无全屏遮罩；已有独立 LoadingCover 的主题无需此项） */
   HEXO_ARTICLE_ROUTE_LOADING: true

--- a/themes/hexo/index.js
+++ b/themes/hexo/index.js
@@ -65,7 +65,7 @@ const LayoutBase = props => {
     hexoArticleRouteLoading && isArticleSlugPage && onLoading
 
   const headerSlot = post ? (
-    <PostHero {...props} />
+    null
   ) : router.route === '/' &&
     siteConfig('HEXO_HOME_BANNER_ENABLE', null, CONFIG) ? (
     <Hero {...props} />
@@ -305,6 +305,14 @@ const LayoutSlug = props => {
             <article
               id='article-wrapper'
               className='subpixel-antialiased overflow-y-hidden'>
+              {/* 文章標題區 */}
+         <div className='px-5 pt-6 mx-auto max-w-2xl lg:max-w-full'>
+                <SmartLink href='/' className='text-sm text-gray-500 hover:underline'>← 回到列表</SmartLink>
+         <div className='mt-4 text-sm text-gray-500'>{post?.category} / {post?.publishDay} 發佈</div>
+          <h1 className='mt-2 text-3xl md:text-4xl font-bold leading-snug dark:text-gray-100'>{post?.title}</h1>
+{post?.tagItems && <div className='mt-4 flex flex-wrap'>{post?.tagItems.map(tag => (<TagItemMini key={tag.name} tag={tag} />))}</div>}
+<hr className='my-6' />
+  </div>
               {/* Notion文章主体 */}
               <section className='px-5 justify-center mx-auto max-w-2xl lg:max-w-full'>
                 {post && <NotionPage post={post} />}

--- a/themes/hexo/style.js
+++ b/themes/hexo/style.js
@@ -29,7 +29,7 @@ const Style = () => {
   return (
     <style jsx global>{`
 /* 客製：內文字級、圖片圓角、標題宋體 */
-#notion-article { font-size: 18px; }
+#notion-article, #notion-article .notion { font-size: 18px; font-family: 'Noto Serif TC', 'Noto Serif SC', serif; }
 #notion-article img { border-radius: 0.75rem; }
 #article-wrapper h1, #notion-article .notion-h1, #notion-article .notion-h2, #notion-article .notion-h3 { font-family: 'Noto Serif TC', 'Noto Serif SC', serif; }
 #theme-hexo {

--- a/themes/hexo/style.js
+++ b/themes/hexo/style.js
@@ -28,7 +28,11 @@ const Style = () => {
 
   return (
     <style jsx global>{`
-      #theme-hexo {
+/* 客製：內文字級、圖片圓角、標題宋體 */
+#notion-article { font-size: 18px; }
+#notion-article img { border-radius: 0.75rem; }
+#article-wrapper h1, #notion-article .notion-h1, #notion-article .notion-h2, #notion-article .notion-h3 { font-family: 'Noto Serif TC', 'Noto Serif SC', serif; }
+#theme-hexo {
         --hexo-color-primary-light: ${primary};
         --hexo-color-primary-dark: ${primaryDark};
         --hexo-color-bg-light: ${background};


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. (示例)版本号管理不规范
   - 版本号直接写在环境变量中，容易出错
   - 多处维护版本号，可能不一致

## 解决方案

1. (示例)将版本号管理从 `.env.local` 迁移到 `package.json`
   - 统一从 `package.json` 读取版本号
   - 使用 IIFE 优雅处理版本号获取逻辑
   - 保持向后兼容，支持环境变量覆盖

## 改动收益

1. (示例)更规范的版本管理
   - 统一从 `package.json` 读取
   - 保持与 npm 生态一致
   - 减少人为错误

## 具体改动

1. （示例）`blog.config.js`
   - 移除原有的静态版本号配置
   - 在文件末尾添加动态版本号获取逻辑
   - 保持向后兼容，优先使用环境变量
   - 添加错误处理和默认值

## 测试确认

- [ ] 本地开发环境测试通过
- [ ] 生产环境构建测试通过
- [ ] （如适用）版本号正确显示
- [ ] （如适用）环境变量配置正常工作

## 用户文档（`docs/user-guide/` / `docs/developer/`）

如果本 PR 新增或修改了站长会使用的功能、主题配置、环境变量、Notion Config 键、插件开关、部署步骤、默认行为或可见 UI 交互，请同步更新 `docs/user-guide/` 或 `docs/developer/` 中对应说明，并在下方勾选已完成项。

只有纯内部重构、测试、CI、依赖维护、拼写修正等不改变站长使用方式的改动，才可以勾选「不适用」。

- [ ] 不适用（无文档改动）
- [ ] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [ ] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [ ] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [ ] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明（可选）：对应官方 slug / URL、是否与功能 PR 配套
