### PR TITLE
fix(notion): 兼容 Gallery 视图的当前数据结构

### DIFF
--- a/__tests__/components/NotionCollectionGallery.test.js
+++ b/__tests__/components/NotionCollectionGallery.test.js
@@ -17,7 +17,7 @@ jest.mock('react-notion-x/build/third-party/collection', () => {
   }
 })
 
-const galleryView = format => ({ type: 'gallery', format })
+const galleryView = format => ({ id: 'gallery_view', type: 'gallery', format })
 
 const galleryRecordMap = {
   block: {
@@ -40,6 +40,43 @@ const galleryRecordMap = {
   },
   collection_query: {},
   signed_urls: {}
+}
+
+const nestedGalleryRecordMap = format => ({
+  ...galleryRecordMap,
+  collection_view: {
+    gallery_view: {
+      spaceId: 'space',
+      value: {
+        role: 'reader',
+        value: galleryView(format)
+      }
+    }
+  }
+})
+
+const nestedGalleryAfterTableRecordMap = format => {
+  const recordMap = nestedGalleryRecordMap(format)
+  return {
+    ...recordMap,
+    block: {
+      collection_view: {
+        value: {
+          ...recordMap.block.collection_view.value,
+          view_ids: ['table_view', 'gallery_view']
+        }
+      }
+    },
+    collection_view: {
+      table_view: {
+        value: {
+          role: 'reader',
+          value: { id: 'table_view', type: 'table', format: {} }
+        }
+      },
+      ...recordMap.collection_view
+    }
+  }
 }
 
 const renderCollectionPropsScript = `
@@ -88,6 +125,51 @@ describe('Notion Gallery visibility settings', () => {
     expect(markup).toContain(
       'class="notion-gallery-hide-page-icons notion-gallery-hide-titles"'
     )
+  })
+
+  it('unwraps the nested collection-view record returned by Notion', () => {
+    const recordMap = nestedGalleryRecordMap({
+      gallery_properties: [{ property: 'title', visible: false }]
+    })
+    const markup = renderToStaticMarkup(
+      React.createElement(NotionCollection, {
+        block: recordMap.block.collection_view.value,
+        ctx: { recordMap }
+      })
+    )
+
+    expect(markup).toContain(
+      'class="notion-gallery-hide-page-icons notion-gallery-hide-titles"'
+    )
+  })
+
+  it('keeps a visible title from the nested collection-view record', () => {
+    const recordMap = nestedGalleryRecordMap({
+      gallery_properties: [{ property: 'title', visible: true }]
+    })
+    const markup = renderToStaticMarkup(
+      React.createElement(NotionCollection, {
+        block: recordMap.block.collection_view.value,
+        ctx: { recordMap }
+      })
+    )
+
+    expect(markup).toContain('class="notion-gallery-hide-page-icons"')
+    expect(markup).not.toContain('notion-gallery-hide-titles')
+  })
+
+  it('uses Gallery settings when Gallery is not the first collection view', () => {
+    const recordMap = nestedGalleryAfterTableRecordMap({
+      gallery_properties: [{ property: 'title', visible: true }]
+    })
+    const markup = renderToStaticMarkup(
+      React.createElement(NotionCollection, {
+        block: recordMap.block.collection_view.value,
+        ctx: { recordMap }
+      })
+    )
+
+    expect(markup).toContain('class="notion-gallery-hide-page-icons"')
   })
 
   it('hides omitted page icons and an explicitly hidden title', () => {

--- a/components/NotionCollection.js
+++ b/components/NotionCollection.js
@@ -2,9 +2,12 @@ import { galleryVisibilityClassName } from '@/lib/notion/galleryVisibilityClassN
 import { Collection } from 'react-notion-x/build/third-party/collection'
 
 export default function NotionCollection(props) {
-  const viewId = props.block?.view_ids?.[0]
-  const collectionViewRecord = props.ctx?.recordMap?.collection_view?.[viewId]
-  const collectionView = collectionViewRecord?.value || collectionViewRecord
+  const collectionView = props.block?.view_ids
+    ?.map(viewId => {
+      const record = props.ctx?.recordMap?.collection_view?.[viewId]
+      return record?.value?.value || record?.value || record
+    })
+    .find(view => view?.type === 'gallery')
   const className = galleryVisibilityClassName(collectionView)
 
   if (!className) return <Collection {...props} />

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2203,12 +2203,13 @@ figure.notion-asset-wrapper.notion-asset-wrapper-video > div {
 }
 
 /* Respect Notion Gallery's "Show page icon" view setting. */
-.notion-gallery-hide-page-icons .notion-page-title-icon {
+.notion-gallery-hide-page-icons .notion-gallery .notion-page-title-icon {
   display: none;
 }
 
 /* Respect the Gallery title property's visibility setting. */
 .notion-gallery-hide-titles
+  .notion-gallery
   .notion-collection-card-body
   > .notion-collection-card-property:first-child {
   display: none;


### PR DESCRIPTION
## 背景

#4316、#4338 和 #4370 先后补齐了 Gallery 图标/Title 的可见性规则和 renderer context 读取路径，但报告者在包含 #4370 的最新 `main` 上仍能复现 #4334。

重新读取当前 Notion API 数据后确认，#4370 仍有两个与真实数据不一致的假设：

1. `collection_view` 记录当前是双层 envelope：`{ value: { role, value: collectionView } }`，而包装器只解包了一层；
2. 当前官方模板的 Gallery 是第 3 个 view，前两个是 Table，而包装器固定读取 `view_ids[0]`。

因此运行时传给 `galleryVisibilityClassName` 的不是 Gallery view，隐藏图标/Title 的 class 始终不会生成。原测试只构造了单层、Gallery 位于首位的数据，所以没有捕获这两个条件。

Fixes #4334

## 解决方案

- 遍历 Collection 的 `view_ids`，兼容单层和双层 `collection_view` envelope，并定位 Gallery view；
- 保留现有 Gallery 可见性 helper 和旧数据回退；
- 将隐藏选择器进一步限定到实际 `.notion-gallery`，避免 Collection 当前显示 Table/Board 时受到 Gallery class 影响；
- 新增真实双层 envelope、Title 隐藏/可见和 Gallery 非首 view 的回归测试。

## 风险与兼容性

- 风险等级：低；不升级依赖，不修改路由、Notion 数据或站点配置；
- 单层旧记录仍可读取；非 Gallery Collection 不生成可见性 class；
- CSS 只在 `.notion-gallery` 内生效，Table/Board/List 保持原样。

## 验证

- [x] 聚焦测试：`9/9`
- [x] 全量 Jest：`53 suites / 283 tests`
- [x] `yarn type-check`
- [x] `yarn lint`（退出码 0，仅仓库既有 warnings）
- [x] `yarn build`（61 个静态页面生成完成，仅仓库既有 warnings）
- [x] 受影响 JS 文件 Prettier 检查
- [x] `git diff --check`
- [x] 浏览器计算样式验收：Gallery 图标/Title 为 `display: none`；同一包装 class 下的 Table 对照仍为 `flex` / `block`

## 用户文档

- [x] 不适用：本次恢复现有 Gallery 配置语义，不新增配置项或部署步骤。
