### PR TITLE
fix: use site pv in analytics cards

### DIFF
--- a/themes/commerce/components/AnalyticsCard.js
+++ b/themes/commerce/components/AnalyticsCard.js
@@ -13,10 +13,10 @@ export function AnalyticsCard (props) {
           <div>{postCount}</div>
         </div>
       </div>
-      <div className='hidden busuanzi_container_page_pv ml-2'>
+      <div className='hidden busuanzi_container_site_pv ml-2'>
         <div className='flex justify-between'>
           <div>访问量:</div>
-          <div className='busuanzi_value_page_pv' />
+          <div className='busuanzi_value_site_pv' />
         </div>
       </div>
       <div className='hidden busuanzi_container_site_uv ml-2'>

--- a/themes/heo/components/AnalyticsCard.js
+++ b/themes/heo/components/AnalyticsCard.js
@@ -31,10 +31,10 @@ export function AnalyticsCard(props) {
                     <div>{diffDays} 天</div>
                 </div>
             </div>
-            <div className='hidden busuanzi_container_page_pv'>
+            <div className='hidden busuanzi_container_site_pv'>
                 <div className='flex justify-between'>
                     <div>{siteVisitTitle}</div>
-                    <div className='busuanzi_value_page_pv' />
+                    <div className='busuanzi_value_site_pv' />
                 </div>
             </div>
             <div className='hidden busuanzi_container_site_uv'>

--- a/themes/hexo/components/AnalyticsCard.js
+++ b/themes/hexo/components/AnalyticsCard.js
@@ -13,10 +13,10 @@ export function AnalyticsCard (props) {
           <div>{postCount}</div>
         </div>
       </div>
-      <div className='hidden busuanzi_container_page_pv ml-2'>
+      <div className='hidden busuanzi_container_site_pv ml-2'>
         <div className='flex justify-between'>
           <div>访问量:</div>
-          <div className='busuanzi_value_page_pv' />
+          <div className='busuanzi_value_site_pv' />
         </div>
       </div>
       <div className='hidden busuanzi_container_site_uv ml-2'>

--- a/themes/matery/components/AnalyticsCard.js
+++ b/themes/matery/components/AnalyticsCard.js
@@ -13,10 +13,10 @@ export function AnalyticsCard (props) {
           <div>{postCount}</div>
         </div>
       </div>
-      <div className='hidden busuanzi_container_page_pv ml-2'>
+      <div className='hidden busuanzi_container_site_pv ml-2'>
         <div className='flex justify-between'>
           <div>访问量:</div>
-          <div className='busuanzi_value_page_pv' />
+          <div className='busuanzi_value_site_pv' />
         </div>
       </div>
       <div className='hidden busuanzi_container_site_uv ml-2'>


### PR DESCRIPTION
Resolves #4472

## 已知问题

1. 部分主题的站点统计卡片与 Footer 显示的“访问量”不一致
   - `AnalyticsCard` 中的“访问量”使用了 `page_pv`，实际表示当前页面访问量
   - Footer 中的访问量使用 `site_pv`，表示全站累计访问量
   - 因此同一页面中两个位置虽然都标记为“访问量”，显示的数值却可能不同
   - Heo 主题中可以直接观察到该问题
   - Hexo、Commerce、Matery 的 `AnalyticsCard` 中也存在相同的统计指标使用问题

## 解决方案

1. 将站点统计卡片中的访问量统一由 `page_pv` 调整为 `site_pv`
   - `busuanzi_container_page_pv` 修改为 `busuanzi_container_site_pv`
   - `busuanzi_value_page_pv` 修改为 `busuanzi_value_site_pv`
   - 访客数继续使用现有的 `site_uv`
   - 不修改文章详情等用于展示单篇文章阅读量的 `page_pv`

2. 同步修复存在相同实现的主题
   - Heo
   - Hexo
   - Commerce
   - Matery

## 改动收益

1. 统一站点统计的指标含义
   - 统计卡片中的“访问量”统一表示全站累计访问量
   - 与 Footer 使用相同的 `site_pv` 数据
   - 避免将当前页面 PV 错误展示为站点访问量

2. 保持现有文章阅读量统计行为不变
   - 文章详情等页面级阅读量仍继续使用 `page_pv`
   - 本次修改仅针对站点级 `AnalyticsCard`

## 具体改动

1. `themes/heo/components/AnalyticsCard.js`
   - 将访问量的 `busuanzi_container_page_pv` 修改为 `busuanzi_container_site_pv`
   - 将 `busuanzi_value_page_pv` 修改为 `busuanzi_value_site_pv`

2. `themes/hexo/components/AnalyticsCard.js`
   - 将访问量统计由 `page_pv` 修改为 `site_pv`

3. `themes/commerce/components/AnalyticsCard.js`
   - 将访问量统计由 `page_pv` 修改为 `site_pv`

4. `themes/matery/components/AnalyticsCard.js`
   - 将访问量统计由 `page_pv` 修改为 `site_pv`

本 PR 不涉及统计卡片开关、主题配置以及其它 Busuanzi 逻辑的调整。

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] Heo 主题统计卡片与 Footer 的访问量保持一致
- [x] 站点访问量正确使用 `site_pv`
- [x] 文章详情中的页面阅读量 `page_pv` 不受影响

## 效果截图

### 修复前

<img width="712" height="968" alt="修复前" src="https://github.com/user-attachments/assets/d94e5f6a-0dc3-43ad-86cd-f07c5f042674" />

### 修复后

<img width="705" height="950" alt="修复后" src="https://github.com/user-attachments/assets/b2dc51a5-3ef3-429a-82c4-ed3f1c0b85bc" />


## 用户文档（`docs/user-guide/` / `docs/developer/`）

如果本 PR 新增或修改了站长会使用的功能、主题配置、环境变量、Notion Config 键、插件开关、部署步骤、默认行为或可见 UI 交互，请同步更新 `docs/user-guide/` 或 `docs/developer/` 中对应说明，并在下方勾选已完成项。

只有纯内部重构、测试、CI、依赖维护、拼写修正等不改变站长使用方式的改动，才可以勾选「不适用」。

- [x] 不适用（无文档改动）
- [x] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [ ] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [ ] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [ ] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明（可选）：本次仅修正现有站点统计卡片使用的 Busuanzi 指标，不新增配置项、不改变站长的使用方式，因此无需更新用户文档。