### PR TITLE
Update Twikoo CDN URL

### DIFF
--- a/conf/comment.config.js
+++ b/conf/comment.config.js
@@ -25,7 +25,7 @@ module.exports = {
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_COUNT_ENABLE || false, // 博客列表是否显示评论数
   COMMENT_TWIKOO_CDN_URL:
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_CDN_URL ||
-    'https://s4.zstatic.net/npm/twikoo@1.7.9/dist/twikoo.min.js', // twikoo客户端cdn
+    'https://cdn.jsdelivr.net/npm/twikoo@1.7.20/dist/twikoo.min.js', // twikoo客户端cdn
 
   // utterance
   COMMENT_UTTERRANCES_REPO:


### PR DESCRIPTION
## 已知问题
 - s4.zstatic.net目前不可用导致评论插件无法加载出来jadelivr的更稳定推荐使用
 - jadelivr的更稳定推荐使用

## 具体改动
`blog.config.js`
   - 原有的静态版本号
   - CDN网址

## 测试确认
生产环境构建测试通过
