### PR TITLE
fix: 更新 Twikoo CDN 地址，解决插件加载失败问题

### DIFF
--- a/conf/comment.config.js
+++ b/conf/comment.config.js
@@ -25,7 +25,7 @@ module.exports = {
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_COUNT_ENABLE || false, // 博客列表是否显示评论数
   COMMENT_TWIKOO_CDN_URL:
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_CDN_URL ||
-    'https://s4.zstatic.net/npm/twikoo@1.7.9/dist/twikoo.min.js', // twikoo客户端cdn
+    'https://cdn.jsdelivr.net/npm/twikoo@1.7.9/dist/twikoo.min.js', // twikoo客户端cdn
 
   // utterance
   COMMENT_UTTERRANCES_REPO:


### PR DESCRIPTION
## 已知问题

s4.zstatic.net的cdn不可用，评论按钮不显示

## 解决方案

将s4.zstatic.net CDN更换为更稳定推荐使用的jsdelivr CDN

## 改动收益

Twikoo插件可恢复正常加载

## 具体改动

`conf/comment.config.js`
   - 移除原有的CDN连接
   - 添加更稳定的CDN链接

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] （如适用）环境变量配置正常工作

## 用户文档（`docs/user-guide/` / `docs/developer/`）

如果本 PR 新增或修改了站长会使用的功能、主题配置、环境变量、Notion Config 键、插件开关、部署步骤、默认行为或可见 UI 交互，请同步更新 `docs/user-guide/` 或 `docs/developer/` 中对应说明，并在下方勾选已完成项。

只有纯内部重构、测试、CI、依赖维护、拼写修正等不改变站长使用方式的改动，才可以勾选「不适用」。

- [x] 不适用（无文档改动）

