### PR TITLE
feat: automate Notion content cache revalidation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@
 # NEXT_PUBLIC_REVALIDATE_SECOND=
 # On-Demand Revalidation Token（设置后可通过 POST /api/revalidate 立即刷新缓存）
 # REVALIDATION_TOKEN=your-secret-token-here
+# Vercel Cron Secret（Vercel 会使用它调用 /api/cron/revalidate）
+# CRON_SECRET=your-cron-secret-here
 # NEXT_PUBLIC_THEME=matery
 # NEXT_PUBLIC_THEME_SWITCH=
 # NEXT_PUBLIC_LANG=

--- a/__tests__/pages/api/cron/revalidate.test.js
+++ b/__tests__/pages/api/cron/revalidate.test.js
@@ -1,0 +1,69 @@
+import handler from '@/pages/api/cron/revalidate'
+import { cleanCache } from '@/lib/cache/local_file_cache'
+
+jest.mock('@/lib/cache/local_file_cache', () => ({
+  cleanCache: jest.fn()
+}))
+
+const createResponse = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+  setHeader: jest.fn(),
+  revalidate: jest.fn().mockResolvedValue(undefined)
+})
+
+describe('GET /api/cron/revalidate', () => {
+  const secret = 'test-cron-secret'
+
+  beforeEach(() => {
+    process.env.CRON_SECRET = secret
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    delete process.env.CRON_SECRET
+  })
+
+  it('requires Vercel Cron authorization', async () => {
+    const req = { method: 'GET', headers: {} }
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(401)
+    expect(res.json).toHaveBeenCalledWith({
+      ok: false,
+      message: 'Unauthorized'
+    })
+    expect(res.revalidate).not.toHaveBeenCalled()
+  })
+
+  it('refreshes the public index paths', async () => {
+    const req = {
+      method: 'GET',
+      headers: { authorization: `Bearer ${secret}` }
+    }
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(cleanCache).toHaveBeenCalledTimes(1)
+    expect(res.revalidate).toHaveBeenCalledTimes(5)
+    expect(res.revalidate).toHaveBeenNthCalledWith(1, '/')
+    expect(res.revalidate).toHaveBeenNthCalledWith(5, '/search')
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it('accepts only GET requests', async () => {
+    const req = {
+      method: 'POST',
+      headers: { authorization: `Bearer ${secret}` }
+    }
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.revalidate).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/pages/api/revalidate.test.js
+++ b/__tests__/pages/api/revalidate.test.js
@@ -1,0 +1,86 @@
+import handler from '@/pages/api/revalidate'
+
+jest.mock('@/lib/cache/local_file_cache', () => ({
+  cleanCache: jest.fn()
+}))
+
+const createResponse = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+  setHeader: jest.fn(),
+  revalidate: jest.fn().mockResolvedValue(undefined)
+})
+
+describe('POST /api/revalidate', () => {
+  const token = 'test-revalidation-token'
+
+  beforeEach(() => {
+    process.env.REVALIDATION_TOKEN = token
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    delete process.env.REVALIDATION_TOKEN
+  })
+
+  it('requires the bearer token in the Authorization header', async () => {
+    const req = {
+      method: 'POST',
+      headers: {},
+      body: { token }
+    }
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(401)
+    expect(res.json).toHaveBeenCalledWith({
+      ok: false,
+      message: 'Unauthorized'
+    })
+    expect(res.revalidate).not.toHaveBeenCalled()
+  })
+
+  it('normalizes and revalidates a single path', async () => {
+    const req = {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}` },
+      body: { path: '/article/sync-test/' }
+    }
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(res.revalidate).toHaveBeenCalledWith('/article/sync-test')
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it('accepts a batch of site paths', async () => {
+    const req = {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}` },
+      body: { paths: ['/', '/archive'] }
+    }
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(res.revalidate).toHaveBeenNthCalledWith(1, '/')
+    expect(res.revalidate).toHaveBeenNthCalledWith(2, '/archive')
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it('rejects unsafe paths', async () => {
+    const req = {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}` },
+      body: { paths: ['//external.example.com'] }
+    }
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.revalidate).not.toHaveBeenCalled()
+  })
+})

--- a/lib/revalidation.js
+++ b/lib/revalidation.js
@@ -1,0 +1,48 @@
+import { timingSafeEqual } from 'node:crypto'
+
+export const MAX_REVALIDATION_PATHS = 50
+
+// Public index routes whose data changes when Notion content or site settings change.
+export const DEFAULT_REVALIDATION_PATHS = [
+  '/',
+  '/archive',
+  '/category',
+  '/tag',
+  '/search'
+]
+
+export function extractBearerToken(authorization) {
+  const header = typeof authorization === 'string' ? authorization : ''
+  if (!header.startsWith('Bearer ')) return ''
+  return header.slice(7).trim()
+}
+
+export function tokensMatch(receivedToken, expectedToken) {
+  if (!receivedToken || !expectedToken) return false
+
+  const received = Buffer.from(receivedToken)
+  const expected = Buffer.from(expectedToken)
+
+  if (received.length !== expected.length) return false
+  return timingSafeEqual(received, expected)
+}
+
+export function isValidRevalidationPath(pathname) {
+  return (
+    typeof pathname === 'string' &&
+    pathname.startsWith('/') &&
+    !pathname.startsWith('//') &&
+    !/[\r\n]/.test(pathname)
+  )
+}
+
+export function normalizeRevalidationPath(pathname) {
+  if (!pathname || typeof pathname !== 'string') return '/'
+
+  let normalized = pathname.trim()
+  if (!normalized.startsWith('/')) normalized = '/' + normalized
+  if (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1)
+  }
+  return normalized
+}

--- a/pages/api/cron/revalidate.js
+++ b/pages/api/cron/revalidate.js
@@ -1,0 +1,55 @@
+import { cleanCache } from '@/lib/cache/local_file_cache'
+import {
+  DEFAULT_REVALIDATION_PATHS,
+  extractBearerToken,
+  tokensMatch
+} from '@/lib/revalidation'
+
+/**
+ * Vercel Cron entrypoint for automatic Notion content refresh.
+ *
+ * Vercel sends Authorization: Bearer <CRON_SECRET> for configured cron jobs.
+ * This route intentionally accepts GET only because Vercel Cron invokes GET.
+ */
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    return res.status(405).json({ ok: false, message: 'Method Not Allowed' })
+  }
+
+  const cronSecret = process.env.CRON_SECRET || ''
+  const receivedToken = extractBearerToken(req.headers.authorization)
+
+  if (!cronSecret || !tokensMatch(receivedToken, cronSecret)) {
+    return res.status(401).json({ ok: false, message: 'Unauthorized' })
+  }
+
+  res.setHeader('Cache-Control', 'no-store, max-age=0')
+
+  try {
+    cleanCache()
+
+    const results = []
+    for (const path of DEFAULT_REVALIDATION_PATHS) {
+      try {
+        await res.revalidate(path)
+        results.push({ path, revalidated: true })
+      } catch (error) {
+        results.push({ path, revalidated: false, error: error.message })
+      }
+    }
+
+    const failed = results.filter(result => !result.revalidated)
+    return res.status(failed.length > 0 ? 500 : 200).json({
+      ok: failed.length === 0,
+      message: `Revalidated ${results.length - failed.length}/${results.length} index paths`,
+      results
+    })
+  } catch (error) {
+    console.error('[cron/revalidate] Error:', error)
+    return res.status(500).json({
+      ok: false,
+      message: 'Automatic revalidation failed'
+    })
+  }
+}

--- a/pages/api/health.js
+++ b/pages/api/health.js
@@ -1,0 +1,25 @@
+import BLOG from '@/blog.config'
+
+/**
+ * Lightweight service health endpoint.
+ * It intentionally returns configuration status only, never credentials or IDs.
+ */
+export default function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    return res.status(405).json({ ok: false, message: 'Method Not Allowed' })
+  }
+
+  res.setHeader('Cache-Control', 'no-store, max-age=0')
+
+  return res.status(200).json({
+    ok: true,
+    service: 'kuoyio-blog',
+    notionConfigured: Boolean(BLOG.NOTION_PAGE_ID),
+    revalidationConfigured: Boolean(
+      process.env.REVALIDATION_TOKEN || BLOG.REVALIDATION_TOKEN
+    ),
+    theme: BLOG.THEME,
+    timestamp: new Date().toISOString()
+  })
+}

--- a/pages/api/health.js
+++ b/pages/api/health.js
@@ -19,6 +19,7 @@ export default function handler(req, res) {
     revalidationConfigured: Boolean(
       process.env.REVALIDATION_TOKEN || BLOG.REVALIDATION_TOKEN
     ),
+    cronConfigured: Boolean(process.env.CRON_SECRET),
     theme: BLOG.THEME,
     timestamp: new Date().toISOString()
   })

--- a/pages/api/revalidate.js
+++ b/pages/api/revalidate.js
@@ -1,8 +1,12 @@
 import BLOG from '@/blog.config'
 import { cleanCache } from '@/lib/cache/local_file_cache'
-import { timingSafeEqual } from 'node:crypto'
-
-const MAX_REVALIDATION_PATHS = 50
+import {
+  extractBearerToken,
+  isValidRevalidationPath,
+  MAX_REVALIDATION_PATHS,
+  normalizeRevalidationPath,
+  tokensMatch
+} from '@/lib/revalidation'
 
 /**
  * On-Demand Revalidation API
@@ -37,9 +41,7 @@ export default async function handler(req, res) {
   }
 
   const authHeader = req.headers.authorization || ''
-  const receivedToken = authHeader.startsWith('Bearer ')
-    ? authHeader.slice(7).trim()
-    : ''
+  const receivedToken = extractBearerToken(authHeader)
 
   if (!tokensMatch(receivedToken, token)) {
     return res.status(401).json({ ok: false, message: 'Unauthorized' })
@@ -75,7 +77,7 @@ export default async function handler(req, res) {
     if (
       targetPaths.length === 0 ||
       targetPaths.length > MAX_REVALIDATION_PATHS ||
-      targetPaths.some(item => !isValidPath(item))
+      targetPaths.some(item => !isValidRevalidationPath(item))
     ) {
       return res.status(400).json({
         ok: false,
@@ -86,7 +88,7 @@ export default async function handler(req, res) {
     const results = []
 
     for (const p of targetPaths) {
-      const normalizedPath = normalizePath(p)
+      const normalizedPath = normalizeRevalidationPath(p)
       try {
         await res.revalidate(normalizedPath)
         results.push({ path: normalizedPath, revalidated: true })
@@ -108,36 +110,4 @@ export default async function handler(req, res) {
       error: error.message
     })
   }
-}
-
-/**
- * 标准化路径：确保以 / 开头，去掉尾部 /
- */
-function normalizePath(p) {
-  if (!p || typeof p !== 'string') return '/'
-  let normalized = p.trim()
-  if (!normalized.startsWith('/')) normalized = '/' + normalized
-  if (normalized.length > 1 && normalized.endsWith('/')) {
-    normalized = normalized.slice(0, -1)
-  }
-  return normalized
-}
-
-function isValidPath(pathname) {
-  return (
-    typeof pathname === 'string' &&
-    pathname.startsWith('/') &&
-    !pathname.startsWith('//') &&
-    !/[\r\n]/.test(pathname)
-  )
-}
-
-function tokensMatch(receivedToken, expectedToken) {
-  if (!receivedToken || !expectedToken) return false
-
-  const received = Buffer.from(receivedToken)
-  const expected = Buffer.from(expectedToken)
-
-  if (received.length !== expected.length) return false
-  return timingSafeEqual(received, expected)
 }

--- a/pages/api/revalidate.js
+++ b/pages/api/revalidate.js
@@ -1,5 +1,8 @@
 import BLOG from '@/blog.config'
 import { cleanCache } from '@/lib/cache/local_file_cache'
+import { timingSafeEqual } from 'node:crypto'
+
+const MAX_REVALIDATION_PATHS = 50
 
 /**
  * On-Demand Revalidation API
@@ -35,10 +38,10 @@ export default async function handler(req, res) {
 
   const authHeader = req.headers.authorization || ''
   const receivedToken = authHeader.startsWith('Bearer ')
-    ? authHeader.slice(7)
-    : req.body?.token || ''
+    ? authHeader.slice(7).trim()
+    : ''
 
-  if (receivedToken !== token) {
+  if (!tokensMatch(receivedToken, token)) {
     return res.status(401).json({ ok: false, message: 'Unauthorized' })
   }
 
@@ -63,7 +66,23 @@ export default async function handler(req, res) {
     }
 
     // 批量刷新
-    const targetPaths = paths || (path ? [path] : ['/'])
+    const targetPaths = Array.isArray(paths)
+      ? paths
+      : path
+        ? [path]
+        : ['/']
+
+    if (
+      targetPaths.length === 0 ||
+      targetPaths.length > MAX_REVALIDATION_PATHS ||
+      targetPaths.some(item => !isValidPath(item))
+    ) {
+      return res.status(400).json({
+        ok: false,
+        message: `paths must contain 1-${MAX_REVALIDATION_PATHS} site paths`
+      })
+    }
+
     const results = []
 
     for (const p of targetPaths) {
@@ -102,4 +121,23 @@ function normalizePath(p) {
     normalized = normalized.slice(0, -1)
   }
   return normalized
+}
+
+function isValidPath(pathname) {
+  return (
+    typeof pathname === 'string' &&
+    pathname.startsWith('/') &&
+    !pathname.startsWith('//') &&
+    !/[\r\n]/.test(pathname)
+  )
+}
+
+function tokensMatch(receivedToken, expectedToken) {
+  if (!receivedToken || !expectedToken) return false
+
+  const received = Buffer.from(receivedToken)
+  const expected = Buffer.from(expectedToken)
+
+  if (received.length !== expected.length) return false
+  return timingSafeEqual(received, expected)
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,13 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "cleanUrls": false,
   "trailingSlash": false,
   "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_MESSAGE\" in *\"[skip-version]\"*) exit 0;; *) exit 1;; esac",
-  "headers": []
+  "headers": [],
+  "crons": [
+    {
+      "path": "/api/cron/revalidate",
+      "schedule": "* * * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Add a protected Vercel Cron endpoint for automatic Notion content refresh
- Centralize revalidation path normalization and Bearer token validation
- Add `/api/health` for deployment diagnostics
- Add unit tests for manual and Cron revalidation
- Configure Vercel Cron to run every minute in Production

## Deployment Configuration

- `CRON_SECRET`: configure as a Secret
- `NEXT_PUBLIC_REVALIDATE_SECOND`: configure as a Config, for example `60`
- `REVALIDATION_TOKEN`: optional Secret for manual revalidation
- Redeploy after changing environment variables

## Validation

- `node --check` passed for changed JavaScript files
- `vercel.json` parsed successfully
- `git diff --check` passed
- Full tests and build were not run locally because dependency installation was blocked by registry network retries

## Notes

- No secrets are committed to the repository
- This PR focuses on the content revalidation pipeline
- Legacy content and OSS image migration will be handled separately